### PR TITLE
Replace "Join Limited Beta" with "Install Birdhouse" and reframe signup for updates

### DIFF
--- a/projects/marketing/assets/script.js
+++ b/projects/marketing/assets/script.js
@@ -206,12 +206,12 @@ window.addEventListener("DOMContentLoaded", async () => {
       const cardBody = form.closest(".card-body");
       cardBody.innerHTML = `
         <div class="text-center space-y-4">
-          <h3 class="text-2xl font-bold text-base-content">🎉 You're on the waitlist!</h3>
+          <h3 class="text-2xl font-bold text-base-content">🎉 You're signed up!</h3>
           <p class="text-base-content/80">
-            We've received your signup for the limited beta starting in March 2026.
+            We'll keep you posted on Birdhouse news and updates.
           </p>
           <p class="text-base-content/60 text-sm">
-            Check your email for updates and exclusive beta access information.
+            Check your email for a confirmation.
           </p>
 
           <div class="divider"></div>
@@ -221,7 +221,7 @@ window.addEventListener("DOMContentLoaded", async () => {
             <a
               href="https://twitter.com/intent/tweet?text=${
         encodeURIComponent(
-          "Just signed up to join the limited beta of @BirdhouseLabsAI, the multi-agent software development tool.\n\nCheck it out:",
+          "Just signed up for updates from @BirdhouseLabsAI, the multi-agent software development tool.\n\nCheck it out:",
         )
       }&url=${encodeURIComponent("https://birdhouselabs.ai")}"
               target="_blank"

--- a/projects/marketing/index.vto
+++ b/projects/marketing/index.vto
@@ -25,8 +25,8 @@ metas:
   </div>
 
   <div class="flex-none">
-    <a href="#waitlist" class="btn btn-primary btn-sm md:btn-md">
-      Join Limited Beta
+    <a href="https://github.com/birdhouse-labs/birdhouse/releases" target="_blank" class="btn btn-primary btn-sm md:btn-md">
+      Get Birdhouse
     </a>
   </div>
 </div>
@@ -48,11 +48,12 @@ metas:
       </p>
       <div class="flex-col md:flex-row justify-between md-4 md:mb-6">
         <a
-          href="#waitlist"
+          href="https://github.com/birdhouse-labs/birdhouse/releases"
+          target="_blank"
           class="btn btn-primary btn-lg md:btn-lg w-full md:w-auto mb-4 md:mb-0 md:mx-4 gap-2 px-8"
         >
           <i data-lucide="bird"></i>
-          Join Limited Beta
+          Get Birdhouse
         </a>
         <a
           href="#features"
@@ -97,7 +98,7 @@ metas:
   </div>
 </div>
 <div
-  class="news_gsap flex overflow-hidden bg-primary py-4 opacity-0 transition-opacity duration-300"
+  class="news_gsap flex overflow-hidden bg-primary py-4 opacity-0 transition-opacity duration-300 hidden"
   id="ticker-container"
 >
   <div id="ticker" class="flex items-center justify-center px-4">
@@ -228,11 +229,12 @@ metas:
         indicate which agents are working so you can check on progress.
       </p>
       <a
-        href="#waitlist"
+        href="https://github.com/birdhouse-labs/birdhouse/releases"
+        target="_blank"
         class="btn btn-primary btn-lg mb-4 md:mb-0 gap-2"
       >
         <i data-lucide="bird"></i>
-        Join Limited Beta
+        Get Birdhouse
       </a>
     </div>
 
@@ -299,18 +301,18 @@ metas:
   <div class="hero-content text-center text-primary flex-col px-4">
     <div class="max-w-2xl">
       <h2 class="text-6xl md:text-7xl mb-6 leading-tight">
-        Want to use Birdhouse first?
+        Stay in the loop
       </h2>
 
       <p class="text-xl text-base-content/70 mb-12">
-        Join the limited beta, starting in March 2026.
+        Sign up for Birdhouse news and updates.
       </p>
 
       <!-- WAITLIST FORM -->
       <div class="card bg-base-100 shadow-2xl max-w-md w-full mx-auto">
         <div class="card-body gap-6">
           <h3 class="card-title text-2xl text-base-content">
-            Join the Waitlist
+            Get Updates
           </h3>
 
           <form class="space-y-4" id="waitlist-form">


### PR DESCRIPTION
CTAs now link to GitHub releases instead of the waitlist anchor.
Signup section repositioned as a newsletter/updates form rather than
beta access. Ticker banner hidden but preserved for future use.
