### PR TITLE
Switch sign-up storage from waitlist to mailing_list table

### DIFF
--- a/projects/birdhouse/server/supabase/migrations/20260306171929_create_mailing_list_table.sql
+++ b/projects/birdhouse/server/supabase/migrations/20260306171929_create_mailing_list_table.sql
@@ -1,0 +1,13 @@
+create table public.mailing_list (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.mailing_list enable row level security;
+
+create policy "Allow anonymous inserts"
+  on public.mailing_list
+  for insert
+  to anon
+  with check (true);

--- a/projects/marketing/assets/script.js
+++ b/projects/marketing/assets/script.js
@@ -195,7 +195,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       };
 
       const { error } = await supabaseClient
-        .from("waitlist")
+        .from("mailing_list")
         .insert(data);
 
       if (error) {


### PR DESCRIPTION
## Summary
- Adds a Supabase migration to create the `mailing_list` table with RLS and an anonymous insert policy
- Updates the marketing site script to insert into `mailing_list` instead of `waitlist`

## Test plan
- [ ] Run the Supabase migration and verify the `mailing_list` table is created
- [ ] Test the sign-up form on the marketing site and confirm entries land in `mailing_list`
- [ ] Verify RLS allows anonymous inserts but blocks other operations