### PR TITLE
Workspace startup warmup - prelaunch 5 recent OpenCode

### DIFF
--- a/projects/birdhouse/server/src/index.ts
+++ b/projects/birdhouse/server/src/index.ts
@@ -12,6 +12,7 @@ import { DATA_DIR, getDataDB, initDataDB } from "./lib/data-db";
 import { log, rootLogger } from "./lib/logger";
 import { OpenCodeManager } from "./lib/opencode-manager";
 import { initPatternGroupsPersistence } from "./lib/pattern-groups-db";
+import { warmRecentWorkspacesInBackground } from "./lib/startup-warmup";
 import { createAAPIMiddleware } from "./middleware/aapi";
 import { createWorkspaceMiddleware } from "./middleware/workspace";
 import { createAAPIAgentRoutes } from "./routes/aapi-agents";
@@ -282,6 +283,7 @@ app.onError((err, c) => {
 
 // Start server
 log.server.info({ port: PORT }, "Birdhouse Server started");
+warmRecentWorkspacesInBackground(dataDb, opencodeManager);
 
 export default {
   port: PORT,

--- a/projects/birdhouse/server/src/lib/startup-warmup.test.ts
+++ b/projects/birdhouse/server/src/lib/startup-warmup.test.ts
@@ -1,0 +1,129 @@
+// ABOUTME: Tests startup workspace warmup behavior for recent workspaces.
+// ABOUTME: Verifies warmup is limited, sequential, and resilient to workspace failures.
+
+import { describe, expect, test } from "bun:test";
+import type { Workspace } from "./data-db";
+import { warmRecentWorkspacesInBackground } from "./startup-warmup";
+
+function createWorkspace(workspaceId: string): Workspace {
+  const now = new Date().toISOString();
+  return {
+    workspace_id: workspaceId,
+    directory: `/tmp/${workspaceId}`,
+    opencode_port: null,
+    opencode_pid: null,
+    created_at: now,
+    last_used: now,
+  };
+}
+
+async function flushMicrotasks(count = 5): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("warmRecentWorkspacesInBackground", () => {
+  test("warms only the five most recent workspaces", async () => {
+    const started: string[] = [];
+    const workspaces = ["ws-1", "ws-2", "ws-3", "ws-4", "ws-5", "ws-6"].map(createWorkspace);
+
+    warmRecentWorkspacesInBackground(
+      {
+        getAllWorkspaces: () => workspaces,
+      },
+      {
+        getOrSpawnOpenCode: async (workspaceId: string) => {
+          started.push(workspaceId);
+          return { port: 1, pid: 1 };
+        },
+      },
+    );
+
+    await flushMicrotasks();
+
+    expect(started).toEqual(["ws-1", "ws-2", "ws-3", "ws-4", "ws-5"]);
+  });
+
+  test("defers warmup work until after startup returns", async () => {
+    const started: string[] = [];
+
+    warmRecentWorkspacesInBackground(
+      {
+        getAllWorkspaces: () => [createWorkspace("ws-1")],
+      },
+      {
+        getOrSpawnOpenCode: async (workspaceId: string) => {
+          started.push(workspaceId);
+          return { port: 1, pid: 1 };
+        },
+      },
+    );
+
+    expect(started).toEqual([]);
+
+    await flushMicrotasks();
+
+    expect(started).toEqual(["ws-1"]);
+  });
+
+  test("warms workspaces sequentially in the background", async () => {
+    const started: string[] = [];
+    const workspaces = [createWorkspace("ws-1"), createWorkspace("ws-2")];
+    let releaseFirst: (() => void) | undefined;
+
+    warmRecentWorkspacesInBackground(
+      {
+        getAllWorkspaces: () => workspaces,
+      },
+      {
+        getOrSpawnOpenCode: async (workspaceId: string) => {
+          started.push(workspaceId);
+
+          if (workspaceId === "ws-1") {
+            await new Promise<void>((resolve) => {
+              releaseFirst = resolve;
+            });
+          }
+
+          return { port: 1, pid: 1 };
+        },
+      },
+    );
+
+    await flushMicrotasks(1);
+
+    expect(started).toEqual(["ws-1"]);
+
+    releaseFirst?.();
+    await flushMicrotasks();
+
+    expect(started).toEqual(["ws-1", "ws-2"]);
+  });
+
+  test("continues warming later workspaces after a failure", async () => {
+    const started: string[] = [];
+    const workspaces = [createWorkspace("ws-1"), createWorkspace("ws-2"), createWorkspace("ws-3")];
+
+    warmRecentWorkspacesInBackground(
+      {
+        getAllWorkspaces: () => workspaces,
+      },
+      {
+        getOrSpawnOpenCode: async (workspaceId: string) => {
+          started.push(workspaceId);
+
+          if (workspaceId === "ws-2") {
+            throw new Error("boom");
+          }
+
+          return { port: 1, pid: 1 };
+        },
+      },
+    );
+
+    await flushMicrotasks();
+
+    expect(started).toEqual(["ws-1", "ws-2", "ws-3"]);
+  });
+});

--- a/projects/birdhouse/server/src/lib/startup-warmup.ts
+++ b/projects/birdhouse/server/src/lib/startup-warmup.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Starts a small set of recent workspace OpenCode instances during server startup.
+// ABOUTME: Runs best-effort warmup in the background so Birdhouse startup stays responsive.
+
+import type { DataDB } from "./data-db";
+import { log } from "./logger";
+import type { OpenCodeManager } from "./opencode-manager";
+
+const RECENT_WORKSPACE_WARMUP_LIMIT = 5;
+
+type WarmupDataDB = Pick<DataDB, "getAllWorkspaces">;
+type WarmupOpenCodeManager = Pick<OpenCodeManager, "getOrSpawnOpenCode">;
+
+export function warmRecentWorkspacesInBackground(
+  dataDb: WarmupDataDB,
+  opencodeManager: WarmupOpenCodeManager,
+  limit = RECENT_WORKSPACE_WARMUP_LIMIT,
+): void {
+  const workspaces = dataDb.getAllWorkspaces().slice(0, limit);
+
+  if (workspaces.length === 0) {
+    log.server.debug("Skipping startup workspace warmup - no workspaces found");
+    return;
+  }
+
+  queueMicrotask(() => {
+    void (async () => {
+      log.server.info(
+        {
+          workspaceCount: workspaces.length,
+          workspaceIds: workspaces.map((workspace) => workspace.workspace_id),
+        },
+        "Starting background OpenCode warmup for recent workspaces",
+      );
+
+      for (const workspace of workspaces) {
+        try {
+          const opencode = await opencodeManager.getOrSpawnOpenCode(workspace.workspace_id);
+          log.server.info(
+            {
+              workspaceId: workspace.workspace_id,
+              port: opencode.port,
+              pid: opencode.pid,
+            },
+            "Background OpenCode warmup completed",
+          );
+        } catch (error) {
+          log.server.warn(
+            {
+              workspaceId: workspace.workspace_id,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Background OpenCode warmup failed",
+          );
+        }
+      }
+
+      log.server.info({ workspaceCount: workspaces.length }, "Background OpenCode warmup finished");
+    })();
+  });
+}
+
+export { RECENT_WORKSPACE_WARMUP_LIMIT };


### PR DESCRIPTION
## Summary
- warm the five most recently used workspaces in the background after Birdhouse starts
- keep warmup sequential and best-effort by reusing the existing `getOrSpawnOpenCode()` path
- add focused tests for the startup limit, non-blocking kickoff, sequential behavior, and failure fallback

## Testing
- bun test src/lib/startup-warmup.test.ts
- bun tsc --noEmit
- bunx biome check src/index.ts src/lib/startup-warmup.ts src/lib/startup-warmup.test.ts