### PR TITLE
Message queue stale pending assistant detection

### DIFF
--- a/projects/birdhouse/frontend/src/domain/message-queue.test.ts
+++ b/projects/birdhouse/frontend/src/domain/message-queue.test.ts
@@ -99,14 +99,26 @@ describe("findPendingAssistantId", () => {
     expect(findPendingAssistantId(messages)).toBe("msg_004");
   });
 
-  it("ignores completed assistant messages and finds incomplete one", () => {
+  it("ignores older completed assistant messages and finds the latest incomplete one", () => {
     const messages = [
-      createAssistantMessage("msg_004", Date.now()), // Completed
+      createUserMessage("msg_004"),
+      createAssistantMessage("msg_003"), // Latest assistant incomplete
+      createUserMessage("msg_002"),
+      createAssistantMessage("msg_001", Date.now()), // Older completed assistant
+    ];
+
+    expect(findPendingAssistantId(messages)).toBe("msg_003");
+  });
+
+  it("returns undefined when the latest assistant is completed even if an older one is incomplete", () => {
+    const messages = [
+      createAssistantMessage("msg_004", Date.now()), // Latest assistant completed
       createUserMessage("msg_003"),
-      createAssistantMessage("msg_002"), // Incomplete
+      createAssistantMessage("msg_002"), // Older incomplete assistant is stale
       createUserMessage("msg_001"),
     ];
-    expect(findPendingAssistantId(messages)).toBe("msg_002");
+
+    expect(findPendingAssistantId(messages)).toBeUndefined();
   });
 });
 

--- a/projects/birdhouse/frontend/src/domain/message-queue.ts
+++ b/projects/birdhouse/frontend/src/domain/message-queue.ts
@@ -6,24 +6,26 @@ import type { Message } from "../types/messages";
 /**
  * Find the ID of the pending (incomplete) assistant message, if any.
  *
- * A pending assistant message is one that:
- * - Has role "assistant"
- * - Does not have a completed timestamp (time.completed is undefined)
+ * A pending assistant message is the latest assistant message when it does not
+ * have a completed timestamp (time.completed is undefined).
  *
  * @param messages Array of messages (newest-first order expected)
  * @returns The ID of the pending assistant message, or undefined if none
  */
 export function findPendingAssistantId(messages: Message[]): string | undefined {
-  // Messages are newest-first, so find the first incomplete assistant message
-  const pending = messages.find((m) => {
+  // Messages are newest-first, so the first assistant message is the latest one.
+  const latestAssistant = messages.find((m) => {
     if (m.role !== "assistant") return false;
-    // Check if the OpenCode message has a completed timestamp
     const ocMessage = m.opencodeMessage;
     if (!ocMessage || ocMessage.role !== "assistant") return false;
-    return !ocMessage.time?.completed;
+    return true;
   });
 
-  return pending?.id;
+  if (!latestAssistant?.opencodeMessage || latestAssistant.opencodeMessage.role !== "assistant") {
+    return undefined;
+  }
+
+  return latestAssistant.opencodeMessage.time?.completed ? undefined : latestAssistant.id;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix queued message detection so only the latest assistant message can keep later user messages in a queued state
- Ignore stale incomplete assistant records once a newer assistant message has completed
- Add regression coverage for stale pending assistant history and latest-assistant behavior

## Release Notes

### Customer-Facing

**Queued message state accuracy**

Queued user messages now clear correctly when a newer assistant reply has already finished. This keeps old incomplete assistant records from making recent turns look like they are still waiting to run.

- Newer completed replies no longer leave the latest user message stuck as queued
- Queue indicators now reflect the most recent assistant activity in the conversation
- Conversation state is easier to trust when older historical messages are incomplete

### Technical

**Message queue stale pending assistant detection** *(commits: 87111eb)*

Pending-assistant detection now keys off the latest assistant message in the newest-first timeline instead of scanning for any incomplete assistant anywhere in history.

Context: The previous heuristic matched the OpenCode TUI logic too literally for Birdhouse UI needs. A stale incomplete assistant from an older turn could incorrectly mark a much newer user message as queued even after a later assistant reply had completed.

**Changes:**
- Update `findPendingAssistantId()` to inspect only the latest assistant message
- Return no pending assistant when that latest assistant already has `time.completed`
- Add regression coverage for stale older incomplete assistants and latest-assistant precedence

## Testing

- `bun run test -- src/domain/message-queue.test.ts`
- `bun run typecheck`
- `bun run check`