### PR TITLE
fix: GitHub org name - birdhouselabs → birdhouse-labs in install URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
             ## Install
 
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/birdhouselabs/birdhouse/main/install.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/birdhouse-labs/birdhouse/main/install.sh | bash
             ```
 
             ## Assets

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # ABOUTME: Downloads the latest release from GitHub and installs to ~/.birdhouse/
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/birdhouselabs/birdhouse/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/birdhouse-labs/birdhouse/main/install.sh | bash
 #   install.sh                        # fetch latest release from GitHub
 #   install.sh /path/to/tarball.tar.gz  # install from a local tarball (skips download + checksum)
 

--- a/projects/birdhouse/scripts/templates/birdhouse.js
+++ b/projects/birdhouse/scripts/templates/birdhouse.js
@@ -125,7 +125,7 @@ function openBrowser(url) {
 
 const UPDATE_CHECK_CACHE = join(CLI_ROOT, 'update-check.json');
 const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const GITHUB_RELEASES_API = 'https://api.github.com/repos/birdhouselabs/birdhouse/releases/latest';
+const GITHUB_RELEASES_API = 'https://api.github.com/repos/birdhouse-labs/birdhouse/releases/latest';
 
 /**
  * Compare two semver strings. Returns true if remote is strictly newer than local.
@@ -375,7 +375,7 @@ async function runUI(args = []) {
   if (updateResult && isNewerVersion(VERSION, updateResult.latestVersion)) {
     log('');
     log(`Update available: v${updateResult.latestVersion} (you have v${VERSION})`);
-    log('  curl -fsSL https://raw.githubusercontent.com/birdhouselabs/birdhouse/main/install.sh | bash');
+    log('  curl -fsSL https://raw.githubusercontent.com/birdhouse-labs/birdhouse/main/install.sh | bash');
   }
   
   if (shouldManageServer) {


### PR DESCRIPTION
## Summary

- Fixes the GitHub org name in three places where `birdhouselabs` (missing hyphen) was used instead of `birdhouse-labs`
- Affected: release workflow install instructions, install script header comment, and CLI update-available prompt