### PR TITLE
zAI (GLM) provider support

### DIFF
--- a/projects/birdhouse/frontend/src/workspace-config/types/provider-registry.test.ts
+++ b/projects/birdhouse/frontend/src/workspace-config/types/provider-registry.test.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Tests for the provider registry metadata
+// ABOUTME: Verifies all expected providers are present with correct ids and labels
+
+import { describe, expect, it } from "vitest";
+import { PROVIDERS } from "./provider-registry";
+
+describe("PROVIDERS registry", () => {
+  it("includes zAI provider with correct id", () => {
+    const zai = PROVIDERS.find((p) => p.id === "zai");
+    expect(zai).toBeDefined();
+  });
+
+  it("includes zAI provider with correct label", () => {
+    const zai = PROVIDERS.find((p) => p.id === "zai");
+    expect(zai?.label).toBe("Z.AI (GLM)");
+  });
+
+  it("includes zAI provider with correct docUrl", () => {
+    const zai = PROVIDERS.find((p) => p.id === "zai");
+    expect(zai?.docUrl).toBe("https://z.ai");
+  });
+
+  it("contains all expected Tier 1 providers", () => {
+    const ids = PROVIDERS.map((p) => p.id);
+    expect(ids).toContain("anthropic");
+    expect(ids).toContain("openai");
+    expect(ids).toContain("google");
+    expect(ids).toContain("openrouter");
+    expect(ids).toContain("groq");
+    expect(ids).toContain("perplexity");
+    expect(ids).toContain("xai");
+    expect(ids).toContain("mistral");
+    expect(ids).toContain("cohere");
+    expect(ids).toContain("deepinfra");
+    expect(ids).toContain("cerebras");
+    expect(ids).toContain("together");
+    expect(ids).toContain("zai");
+  });
+});

--- a/projects/birdhouse/frontend/src/workspace-config/types/provider-registry.ts
+++ b/projects/birdhouse/frontend/src/workspace-config/types/provider-registry.ts
@@ -26,6 +26,7 @@ export const PROVIDERS: ProviderMetadata[] = [
   { id: "deepinfra", label: "DeepInfra", docUrl: "https://deepinfra.com/dash/api_keys" },
   { id: "cerebras", label: "Cerebras", docUrl: "https://cloud.cerebras.ai/api-keys" },
   { id: "together", label: "Together AI", docUrl: "https://api.together.xyz/settings/api-keys" },
+  { id: "zai", label: "Z.AI (GLM)", docUrl: "https://z.ai" },
 ];
 
 /**

--- a/projects/birdhouse/server/src/lib/secrets.test.ts
+++ b/projects/birdhouse/server/src/lib/secrets.test.ts
@@ -67,6 +67,7 @@ describe("providersToEnv", () => {
       deepinfra: { api_key: "di-stu" },
       cerebras: { api_key: "cerebras-vwx" },
       together: { api_key: "together-yz" },
+      zai: { api_key: "zai-abc" },
     };
 
     const env = providersToEnv(providers);
@@ -83,6 +84,17 @@ describe("providersToEnv", () => {
     expect(env.DEEPINFRA_API_KEY).toBe("di-stu");
     expect(env.CEREBRAS_API_KEY).toBe("cerebras-vwx");
     expect(env.TOGETHER_API_KEY).toBe("together-yz");
+    expect(env.ZHIPU_API_KEY).toBe("zai-abc");
+  });
+
+  test("maps zAI provider correctly", () => {
+    const providers: ProviderCredentials = {
+      zai: { api_key: "zhipu-key-123" },
+    };
+
+    const env = providersToEnv(providers);
+
+    expect(env.ZHIPU_API_KEY).toBe("zhipu-key-123");
   });
 
   test("maps AWS provider correctly", () => {

--- a/projects/birdhouse/server/src/lib/secrets.ts
+++ b/projects/birdhouse/server/src/lib/secrets.ts
@@ -36,6 +36,7 @@ export interface ProviderCredentials {
   deepinfra?: { api_key: string };
   cerebras?: { api_key: string };
   together?: { api_key: string };
+  zai?: { api_key: string };
 
   // Tier 2: Complex multi-key providers
   aws?: {
@@ -144,6 +145,9 @@ export function providersToEnv(providers: ProviderCredentials): Record<string, s
   }
   if (providers.together?.api_key) {
     env.TOGETHER_API_KEY = providers.together.api_key;
+  }
+  if (providers.zai?.api_key) {
+    env.ZHIPU_API_KEY = providers.zai.api_key;
   }
 
   // Tier 2: Complex multi-key providers


### PR DESCRIPTION
Closes #21

## What's New

Z.AI (GLM) is now available as a provider in Birdhouse. Add your `ZHIPU_API_KEY` in workspace settings to access GLM-4 and GLM-5 models.

## Technical Changes

- `ProviderCredentials`: added `zai?: { api_key: string }` alongside other Tier 1 providers *(secrets.ts)*
- `providersToEnv()`: maps `credentials.zai.api_key` → `ZHIPU_API_KEY` env var injected into OpenCode at spawn *(secrets.ts)*
- `PROVIDERS` registry: added `{ id: "zai", label: "Z.AI (GLM)", docUrl: "https://z.ai" }` *(provider-registry.ts)*
- Tests extended to cover the new provider in both server and frontend

No architectural changes — zAI uses a single API key, fitting cleanly into the existing Tier 1 provider pattern.