### PR TITLE
PostHog user identification

### DIFF
--- a/projects/birdhouse/frontend/src/App.tsx
+++ b/projects/birdhouse/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import WorkspaceLayout from "./components/WorkspaceLayout";
 import WorkspaceSelector from "./components/WorkspaceSelector";
 import WorkspaceSetup from "./components/WorkspaceSetup";
 import { log } from "./lib/logger";
+import { identifyPosthogUser } from "./lib/posthog";
 import { fetchUserProfile } from "./services/user-profile-api";
 
 const REDIRECT_KEY = "birdhouse.setup.redirect";
@@ -29,7 +30,8 @@ const ProfileRedirect: Component<{ children: JSX.Element }> = (props) => {
 
     const isProfilePage = location.pathname === "/setup/profile";
     const profileLoaded = !profile.error && profile() !== undefined;
-    const hasName = profileLoaded && !!profile()?.name;
+    const data = profile();
+    const hasName = profileLoaded && !!data?.name;
 
     log.ui.info("ProfileRedirect effect running", {
       hasName,
@@ -37,6 +39,11 @@ const ProfileRedirect: Component<{ children: JSX.Element }> = (props) => {
       pathname: location.pathname,
       loading: profile.loading,
     });
+
+    // Identify the user in PostHog whenever we have both a name and install ID
+    if (hasName && data?.installId && data.name) {
+      identifyPosthogUser(data.installId, data.name);
+    }
 
     // Already on the profile page and name is now set — redirect back
     if (isProfilePage && hasName) {

--- a/projects/birdhouse/frontend/src/components/SetupProfile.tsx
+++ b/projects/birdhouse/frontend/src/components/SetupProfile.tsx
@@ -2,8 +2,9 @@
 // ABOUTME: Shown once before accessing the app; redirects to workspace selector on submit
 
 import { useNavigate, useSearchParams } from "@solidjs/router";
-import { type Component, createSignal, Show } from "solid-js";
-import { submitUserName } from "../services/user-profile-api";
+import { type Component, createResource, createSignal, Show } from "solid-js";
+import { identifyPosthogUser } from "../lib/posthog";
+import { fetchUserProfile, submitUserName } from "../services/user-profile-api";
 import Button from "./ui/Button";
 
 const REDIRECT_KEY = "birdhouse.setup.redirect";
@@ -11,6 +12,7 @@ const REDIRECT_KEY = "birdhouse.setup.redirect";
 const SetupProfile: Component = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const [profile] = createResource(fetchUserProfile);
 
   const [name, setName] = createSignal("");
   const [isSubmitting, setIsSubmitting] = createSignal(false);
@@ -31,6 +33,11 @@ const SetupProfile: Component = () => {
 
     try {
       await submitUserName(trimmedName);
+
+      const installId = profile()?.installId;
+      if (installId) {
+        identifyPosthogUser(installId, trimmedName);
+      }
 
       const redirect = redirectParam() ?? sessionStorage.getItem(REDIRECT_KEY);
       sessionStorage.removeItem(REDIRECT_KEY);

--- a/projects/birdhouse/frontend/src/lib/posthog.test.ts
+++ b/projects/birdhouse/frontend/src/lib/posthog.test.ts
@@ -1,28 +1,51 @@
-// ABOUTME: Verifies PostHog identity builder maps user fields correctly
-// ABOUTME: Ensures display name falls back to email when needed
+// ABOUTME: Verifies PostHog user identification calls posthog.identify correctly
+// ABOUTME: Ensures name is passed as the display name property
 
-import { describe, expect, it } from "vitest";
-import { buildPosthogIdentity } from "./posthog";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("buildPosthogIdentity", () => {
-  it("uses full_name when available", () => {
-    const user = {
-      id: "user-123",
-      email: "cody@example.com",
-      user_metadata: {
-        full_name: "Test User",
-      },
-    };
+const mockIdentify = vi.fn();
+const mockInit = vi.fn();
+const mockRegister = vi.fn();
+const mockReset = vi.fn();
 
-    const identity = buildPosthogIdentity(user);
+vi.mock("posthog-js", () => ({
+  default: {
+    identify: mockIdentify,
+    init: mockInit,
+    reset: mockReset,
+    config: {},
+  },
+}));
 
-    expect(identity).toEqual({
-      distinctId: "user-123",
-      properties: {
-        email: "cody@example.com",
-        name: "Test User",
-        username: "Test User",
-      },
+vi.mock("posthog-js/dist/recorder", () => ({}));
+vi.mock("posthog-js/dist/external-scripts-loader", () => ({}));
+
+// Import after mocks are set up
+const { identifyPosthogUser, initPosthog } = await import("./posthog");
+
+describe("identifyPosthogUser", () => {
+  beforeEach(() => {
+    mockIdentify.mockClear();
+    mockInit.mockClear();
+    mockRegister.mockClear();
+
+    // Simulate the loaded callback to set initialized = true
+    mockInit.mockImplementation((_key: string, opts: { loaded?: (ph: unknown) => void }) => {
+      opts?.loaded?.({ register: mockRegister });
     });
+
+    initPosthog();
+  });
+
+  it("calls posthog.identify with installId as distinctId and name as display name", () => {
+    identifyPosthogUser("install-abc123", "Cody");
+
+    expect(mockIdentify).toHaveBeenCalledWith("install-abc123", { name: "Cody" });
+  });
+
+  it("passes the name through unchanged", () => {
+    identifyPosthogUser("install-xyz", "Jane Smith");
+
+    expect(mockIdentify).toHaveBeenCalledWith("install-xyz", { name: "Jane Smith" });
   });
 });

--- a/projects/birdhouse/frontend/src/lib/posthog.ts
+++ b/projects/birdhouse/frontend/src/lib/posthog.ts
@@ -6,42 +6,11 @@ import "posthog-js/dist/recorder";
 import "posthog-js/dist/external-scripts-loader";
 import { log } from "./logger";
 
-/**
- * Minimal user shape needed for PostHog identification.
- * Compatible with Supabase User and other auth providers.
- */
-export interface AuthUser {
-  id: string;
-  email?: string;
-  user_metadata?: Record<string, unknown>;
-}
-
 const posthogKey = "phc_LwyUqyfUjlP28aI98eE2K7jA6mdTboPZYRuKotWsoYI";
 let initialized = false;
 
 const toolbarParamsKey = "_postHogToolbarParams";
 const maskedTextSelector = ".ph-mask-text";
-
-export type PosthogIdentity = {
-  distinctId: string;
-  properties: Record<string, string | boolean | number | null | undefined>;
-};
-
-export function buildPosthogIdentity(user: AuthUser): PosthogIdentity {
-  const displayName = (user.user_metadata?.["full_name"] ??
-    user.user_metadata?.["name"] ??
-    user.email ??
-    user.id) as string;
-
-  return {
-    distinctId: user.id,
-    properties: {
-      email: user.email,
-      name: displayName,
-      username: displayName,
-    },
-  };
-}
 
 export function initPosthog() {
   if (initialized) return;
@@ -86,11 +55,10 @@ export function initPosthog() {
   initialized = true;
 }
 
-export function identifyPosthogUser(user: AuthUser) {
+export function identifyPosthogUser(installId: string, name: string) {
   if (!initialized || !posthogKey) return;
 
-  const { distinctId, properties } = buildPosthogIdentity(user);
-  posthog.identify(distinctId, properties);
+  posthog.identify(installId, { name });
 }
 
 export function resetPosthogUser() {

--- a/projects/birdhouse/frontend/src/services/user-profile-api.ts
+++ b/projects/birdhouse/frontend/src/services/user-profile-api.ts
@@ -5,6 +5,7 @@ import { API_ENDPOINT_BASE } from "../config/api";
 
 export interface UserProfileResponse {
   name: string | null;
+  installId: string;
 }
 
 export async function fetchUserProfile(): Promise<UserProfileResponse> {

--- a/projects/birdhouse/server/src/routes/user-profile.ts
+++ b/projects/birdhouse/server/src/routes/user-profile.ts
@@ -1,5 +1,5 @@
 // ABOUTME: User profile routes for Birdhouse — stores the user's display name locally
-// ABOUTME: GET returns current name, PATCH sets name; name is required before using the app
+// ABOUTME: GET returns current name and stable install ID, PATCH sets name; name is required before using the app
 
 import { Hono } from "hono";
 import type { DataDB } from "../lib/data-db";
@@ -7,6 +7,7 @@ import { log } from "../lib/logger";
 
 export interface UserProfileResponse {
   name: string | null;
+  installId: string;
 }
 
 export function createUserProfileRoutes(dataDb: DataDB) {
@@ -14,11 +15,12 @@ export function createUserProfileRoutes(dataDb: DataDB) {
 
   /**
    * GET /api/user-profile
-   * Returns the stored user name, or null if not yet set.
+   * Returns the stored user name (or null if not yet set) and the stable install ID.
    */
   app.get("/", (c) => {
     const name = dataDb.getUserName();
-    return c.json<UserProfileResponse>({ name });
+    const installId = dataDb.getOrCreateInstallId();
+    return c.json<UserProfileResponse>({ name, installId });
   });
 
   /**


### PR DESCRIPTION
Identify users in PostHog so analytics events are attributed to a name rather than appearing anonymous.