### PR TITLE
Skills reload: use narrow OpenCode refresh

### DIFF
--- a/projects/birdhouse/frontend/src/LiveApp.tsx
+++ b/projects/birdhouse/frontend/src/LiveApp.tsx
@@ -534,20 +534,6 @@ const LiveApp: Component<LiveAppProps> = (props) => {
     return results.length;
   });
 
-  const hasActiveAgents = createMemo(() => {
-    const hasActiveDescendant = (nodes: TreeNode[]): boolean => {
-      return nodes.some((node) => {
-        if (node.status?.type === "busy" || node.status?.type === "retry") {
-          return true;
-        }
-
-        return hasActiveDescendant(node.children);
-      });
-    };
-
-    return hasActiveDescendant(treeWithCollapsedState());
-  });
-
   // Tree view component with loading/error/empty states
   // Wrapped with AgentTreeProvider to avoid prop drilling through TreeView
   const TreeViewContent = () => (
@@ -727,7 +713,7 @@ const LiveApp: Component<LiveAppProps> = (props) => {
       </For>
 
       {/* Skills Library Dialog */}
-      <SkillLibraryDialog workspaceId={workspaceId} hasActiveAgents={hasActiveAgents()} />
+      <SkillLibraryDialog workspaceId={workspaceId} />
     </div>
   );
 };

--- a/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.test.tsx
@@ -321,14 +321,14 @@ describe("SkillLibraryDialog", () => {
     });
   });
 
-  it("disables reload while agents are active", async () => {
+  it("keeps reload available while agents are active", async () => {
     fetchSkillLibraryMock.mockResolvedValue({ skills: [] });
     reloadSkillsMock.mockResolvedValue(undefined);
 
-    render(() => <SkillLibraryDialog workspaceId="ws_test" hasActiveAgents />);
+    render(() => <SkillLibraryDialog workspaceId="ws_test" />);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Reload Skills" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Reload Skills" })).toBeEnabled();
     });
   });
 });

--- a/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
@@ -65,7 +65,6 @@ function saveSkillLibraryUIState(workspaceId: string, state: SkillLibraryUIState
 
 export interface SkillLibraryDialogProps {
   workspaceId: string;
-  hasActiveAgents?: boolean;
 }
 
 const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
@@ -163,7 +162,7 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
   };
 
   const handleReloadSkills = async () => {
-    if (reloadingSkills() || props.hasActiveAgents) {
+    if (reloadingSkills()) {
       return;
     }
 
@@ -289,7 +288,7 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
               <Button
                 variant="secondary"
                 onClick={handleReloadSkills}
-                disabled={reloadingSkills() || !!props.hasActiveAgents}
+                disabled={reloadingSkills()}
                 leftIcon={<RefreshCw size={16} classList={{ "animate-spin": reloadingSkills() }} />}
                 class="whitespace-nowrap"
                 aria-label="Reload Skills"

--- a/projects/birdhouse/server/src/lib/opencode-client.ts
+++ b/projects/birdhouse/server/src/lib/opencode-client.ts
@@ -100,7 +100,7 @@ export interface OpenCodeClient {
   waitForSessionCompletion(sessionId: string): Promise<Message>;
   getProviders(): Promise<ProvidersResponse>;
   listSkills(): Promise<Skill[]>;
-  disposeInstance(): Promise<void>;
+  reloadSkillState(): Promise<void>;
   generate(options: {
     prompt?: string;
     system?: string[];
@@ -255,13 +255,13 @@ export function createLiveOpenCodeClient(baseUrl: string, workspaceRoot: string)
       return response.json() as Promise<Skill[]>;
     },
 
-    async disposeInstance(): Promise<void> {
-      const response = await fetch(`${baseUrl}/instance/dispose?directory=${encodeURIComponent(workspaceRoot)}`, {
+    async reloadSkillState(): Promise<void> {
+      const response = await fetch(`${baseUrl}/skill/reload?directory=${encodeURIComponent(workspaceRoot)}`, {
         method: "POST",
       });
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Failed to dispose instance: ${response.statusText} - ${errorText}`);
+        throw new Error(`Failed to reload skill state: ${response.statusText} - ${errorText}`);
       }
     },
 
@@ -588,7 +588,7 @@ export function createTestOpenCodeClient(): OpenCodeClient {
       return [];
     },
 
-    async disposeInstance(): Promise<void> {
+    async reloadSkillState(): Promise<void> {
       // Mock implementation - no-op
     },
 

--- a/projects/birdhouse/server/src/routes/skills.test.ts
+++ b/projects/birdhouse/server/src/routes/skills.test.ts
@@ -299,14 +299,14 @@ metadata:
     });
   });
 
-  test("reloads workspace skills by disposing the OpenCode instance", async () => {
+  test("reloads workspace skills via the OpenCode skill reload endpoint", async () => {
     const workspace = createWorkspace("ws_1", "/repo/current-workspace");
     testDb.insertWorkspace(workspace);
-    let disposeCalled = 0;
+    let reloadCalled = 0;
 
     const deps = createTestDeps({
-      disposeInstance: async () => {
-        disposeCalled += 1;
+      reloadSkillState: async () => {
+        reloadCalled += 1;
       },
     });
 
@@ -318,7 +318,7 @@ metadata:
 
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({ success: true });
-      expect(disposeCalled).toBe(1);
+      expect(reloadCalled).toBe(1);
     });
   });
 

--- a/projects/birdhouse/server/src/routes/skills.ts
+++ b/projects/birdhouse/server/src/routes/skills.ts
@@ -90,7 +90,7 @@ export function createSkillRoutes(dataDb: DataDB) {
   app.post("/reload", async (c) => {
     const { opencode } = getDepsFromContext(c);
 
-    await opencode.disposeInstance();
+    await opencode.reloadSkillState();
 
     return c.json({ success: true });
   });


### PR DESCRIPTION
## What's New

- Updated the Skills Library Reload Skills action to use OpenCode's new narrow skill reload path instead of full instance disposal, so skills can be refreshed without interrupting active agents.

## Technical Changes

- Swapped Birdhouse reload calls from instance disposal to the new OpenCode skill-state reload endpoint.
- Removed the frontend guard that disabled reload while agents were active, since the new reload path no longer tears down the running OpenCode instance.
- Updated server and frontend tests to cover the new contract and enabled-button behavior.

## Files Changed

- projects/birdhouse/server/src/lib/opencode-client.ts - new narrow reload client method
- projects/birdhouse/server/src/routes/skills.ts - reload route now calls skill-state refresh
- projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx - reload button remains available during active agent work
- projects/birdhouse/frontend/src/LiveApp.tsx - removed active-agent gating for the dialog

## Testing

- bun test src/routes/skills.test.ts && bun run typecheck in projects/birdhouse/server
- bun run lint && bun --bun vitest run src/skills/services/skill-library-api.test.ts src/skills/components/SkillLibraryDialog.test.tsx && bun run typecheck in projects/birdhouse/frontend
- Manual local verification: reloaded skills multiple times without interrupting active agents while using the OpenCode cody/narrow-skill-reload branch
