### PR TITLE
Page titles: descriptive browser tab titles for all routes

### DIFF
--- a/projects/birdhouse/frontend/src/LiveApp.tsx
+++ b/projects/birdhouse/frontend/src/LiveApp.tsx
@@ -21,6 +21,7 @@ import { useStreaming } from "./contexts/StreamingContext";
 import { useWorkspace } from "./contexts/WorkspaceContext";
 import { loadCollapseState, saveCollapseState } from "./lib/collapse-state";
 import { log } from "./lib/logger";
+import { usePageTitle } from "./lib/page-title";
 import { keepAgentInView } from "./lib/preferences";
 import { useModalRoute, useNavigateToWorkspaceAgent, useWorkspaceAgentId } from "./lib/routing";
 import { searchAgents } from "./services/agents-api";
@@ -381,29 +382,15 @@ const LiveApp: Component<LiveAppProps> = (props) => {
   });
 
   // Update browser tab title to show selected agent name
-  createEffect(() => {
+  usePageTitle(() => {
     const agentId = selectedAgentId();
 
     if (!agentId) {
-      // No agent selected - use default title
-      document.title = "Birdhouse";
-      return;
+      return "New Agent - Birdhouse";
     }
 
-    // Find agent in tree to get its title
     const agent = findNodeById(treeWithCollapsedState(), agentId);
-
-    if (agent) {
-      document.title = `${agent.title} - Birdhouse`;
-    } else {
-      // Agent not found yet (loading or error) - use default
-      document.title = "Birdhouse";
-    }
-  });
-
-  // Reset title when component unmounts
-  onCleanup(() => {
-    document.title = "Birdhouse";
+    return agent ? `${agent.title} - Birdhouse` : "New Agent - Birdhouse";
   });
 
   // Agent selection handler - navigate to new route

--- a/projects/birdhouse/frontend/src/Playground.tsx
+++ b/projects/birdhouse/frontend/src/Playground.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Split-view layout with resizable sidebar and component demo viewer
 
 import Resizable from "corvu/resizable";
-import { type Component, createEffect, createSignal, onCleanup, Show } from "solid-js";
+import { type Component, createEffect, createMemo, createSignal, Show } from "solid-js";
 import ComponentNav from "./components/ComponentNav";
 import MobileNavDrawer from "./components/MobileNavDrawer";
 import {
@@ -26,6 +26,7 @@ import {
   TooltipDemo,
   TreeViewDemo,
 } from "./demos";
+import { usePageTitle } from "./lib/page-title";
 import { usePlaygroundComponent, useSetPlaygroundComponent } from "./lib/routing";
 import { createMediaQuery } from "./theme/createMediaQuery";
 
@@ -184,15 +185,12 @@ const Playground: Component<PlaygroundProps> = (props) => {
     }
   });
 
-  // Update browser tab title to show "Playground - Birdhouse"
-  createEffect(() => {
-    document.title = "Playground - Birdhouse";
+  const selectedComponentName = createMemo(() => {
+    const item = components.find((c) => c.id === selectedComponent());
+    return item?.name ?? selectedComponent();
   });
 
-  // Reset title when component unmounts
-  onCleanup(() => {
-    document.title = "Birdhouse";
-  });
+  usePageTitle(() => `${selectedComponentName()} - Playground - Birdhouse`);
 
   // Handle component selection - navigate to new route
   const handleSelectComponent = (id: string) => {

--- a/projects/birdhouse/frontend/src/components/SetupProfile.tsx
+++ b/projects/birdhouse/frontend/src/components/SetupProfile.tsx
@@ -3,6 +3,7 @@
 
 import { useNavigate, useSearchParams } from "@solidjs/router";
 import { type Component, createResource, createSignal, Show } from "solid-js";
+import { usePageTitle } from "../lib/page-title";
 import { identifyPosthogUser } from "../lib/posthog";
 import { fetchUserProfile, submitUserName } from "../services/user-profile-api";
 import Button from "./ui/Button";
@@ -10,6 +11,8 @@ import Button from "./ui/Button";
 const REDIRECT_KEY = "birdhouse.setup.redirect";
 
 const SetupProfile: Component = () => {
+  usePageTitle("Profile Setup - Birdhouse");
+
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [profile] = createResource(fetchUserProfile);

--- a/projects/birdhouse/frontend/src/components/WorkspaceSelector.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceSelector.tsx
@@ -5,6 +5,7 @@
 import { useNavigate } from "@solidjs/router";
 import { RefreshCw } from "lucide-solid";
 import { type Component, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { usePageTitle } from "../lib/page-title";
 import { useModalRoute } from "../lib/routing";
 import { fetchWorkspaces, fetchWorkspacesHealth } from "../services/workspaces-api";
 import type { Workspace, WorkspaceHealthStatus as WorkspaceHealthStatusType } from "../types/workspace";
@@ -30,6 +31,8 @@ const ErrorMessage = (props: { error: Error; onRetry: () => void }) => (
 );
 
 const WorkspaceSelector: Component = () => {
+  usePageTitle("Workspaces - Birdhouse");
+
   const navigate = useNavigate();
   const [workspaces, setWorkspaces] = createSignal<Workspace[]>([]);
   const [isLoading, setIsLoading] = createSignal(true);

--- a/projects/birdhouse/frontend/src/components/WorkspaceSettings.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceSettings.tsx
@@ -5,6 +5,7 @@
 import { useNavigate } from "@solidjs/router";
 import { type Component, createSignal, Show } from "solid-js";
 import { useWorkspace } from "../contexts/WorkspaceContext";
+import { usePageTitle } from "../lib/page-title";
 import { useModalRoute } from "../lib/routing";
 import { deleteWorkspace } from "../services/workspaces-api";
 import WorkspaceConfigDialog from "../workspace-config/components/WorkspaceConfigDialog";
@@ -17,6 +18,8 @@ const LoadingSpinner = () => (
 );
 
 const WorkspaceSettings: Component = () => {
+  usePageTitle("Workspace Settings - Birdhouse");
+
   const navigate = useNavigate();
   const { workspaceId, workspace, isLoading, error, refetch } = useWorkspace();
   const { currentModal, openModal, closeModal, isModalOpen } = useModalRoute();

--- a/projects/birdhouse/frontend/src/components/WorkspaceSetup.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceSetup.tsx
@@ -3,6 +3,7 @@
 
 import { useNavigate, useSearchParams } from "@solidjs/router";
 import { type Component, createSignal, onMount, Show } from "solid-js";
+import { usePageTitle } from "../lib/page-title";
 import { checkWorkspace, createWorkspace } from "../services/workspaces-api";
 import Button from "./ui/Button";
 
@@ -13,6 +14,8 @@ const LoadingSpinner = () => (
 );
 
 const WorkspaceSetup: Component = () => {
+  usePageTitle("New Workspace - Birdhouse");
+
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 

--- a/projects/birdhouse/frontend/src/lib/page-title.ts
+++ b/projects/birdhouse/frontend/src/lib/page-title.ts
@@ -1,0 +1,19 @@
+// ABOUTME: Utility for setting the browser tab title reactively
+// ABOUTME: Resets to "Birdhouse" on cleanup when component unmounts
+
+import type { Accessor } from "solid-js";
+import { createEffect, onCleanup } from "solid-js";
+
+/**
+ * Sets document.title reactively from an accessor or static string.
+ * Resets to "Birdhouse" when the calling component unmounts.
+ */
+export function usePageTitle(title: string | Accessor<string>): void {
+  createEffect(() => {
+    document.title = typeof title === "function" ? title() : title;
+  });
+
+  onCleanup(() => {
+    document.title = "Birdhouse";
+  });
+}


### PR DESCRIPTION
## What's New

### ✨ Features
- Browser tab titles are now descriptive on every page — no more generic "Birdhouse" when no agent is selected

| Route | Tab title |
|---|---|
| Workspace selector | Workspaces - Birdhouse |
| Workspace setup | New Workspace - Birdhouse |
| Profile setup | Profile Setup - Birdhouse |
| Agents view (no agent) | New Agent - Birdhouse |
| Agent view | {Agent Title} - Birdhouse |
| Workspace settings | Workspace Settings - Birdhouse |
| Playground | {Component Name} - Playground - Birdhouse |

---

## Technical Changes

### 🏗️ Infrastructure
- Added `lib/page-title.ts` — a small `usePageTitle(title)` hook that accepts a static string or a reactive accessor, sets `document.title`, and resets to `"Birdhouse"` on unmount

### 🧹 Code Quality
- Replaced ad-hoc `createEffect` + `onCleanup` title management in `LiveApp.tsx` and `Playground.tsx` with the shared `usePageTitle` hook

## Files Changed
- `src/lib/page-title.ts` — new `usePageTitle()` hook
- `src/LiveApp.tsx` — uses hook; fallback changed from `"Birdhouse"` to `"New Agent - Birdhouse"`
- `src/Playground.tsx` — uses hook; title now includes the selected component name
- `src/components/WorkspaceSelector.tsx` — `"Workspaces - Birdhouse"`
- `src/components/WorkspaceSetup.tsx` — `"New Workspace - Birdhouse"`
- `src/components/SetupProfile.tsx` — `"Profile Setup - Birdhouse"`
- `src/components/WorkspaceSettings.tsx` — `"Workspace Settings - Birdhouse"`

## Testing
- All 658 frontend tests pass
- TypeScript typecheck clean
- Biome lint clean (pre-existing warning in `LiveMessages.tsx` unrelated to this change)