### PR TITLE
SkillAttachmentsDialog - add 'Open in skill library' button

### DIFF
--- a/projects/birdhouse/frontend/src/components/NewAgent.tsx
+++ b/projects/birdhouse/frontend/src/components/NewAgent.tsx
@@ -372,6 +372,7 @@ const NewAgent: Component = () => {
         attachments={visibleSkillAttachments()}
         open={skillDialogOpen()}
         onClose={() => setSkillDialogOpen(false)}
+        workspaceId={workspaceId}
       />
     </div>
   );

--- a/projects/birdhouse/frontend/src/components/ui/ChatContainer.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/ChatContainer.tsx
@@ -190,6 +190,7 @@ export const ChatContainer: Component<ChatContainerProps> = (props) => {
         attachments={visibleSkillAttachments()}
         open={dialogOpen()}
         onClose={() => setDialogOpen(false)}
+        workspaceId={workspaceId}
       />
 
       {/* Messages area - newest at top (scrollable) */}

--- a/projects/birdhouse/frontend/src/components/ui/MessageBubble.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/MessageBubble.tsx
@@ -583,6 +583,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
           setSkillDialogOpen(false);
           setSelectedSkillName(undefined);
         }}
+        workspaceId={workspaceId}
         {...(selectedSkillName() ? { initialSkillName: selectedSkillName() } : {})}
       />
 

--- a/projects/birdhouse/frontend/src/components/ui/SkillAttachmentsDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/SkillAttachmentsDialog.tsx
@@ -5,8 +5,10 @@ import Dialog from "corvu/dialog";
 import { LibraryBig } from "lucide-solid";
 import { type Component, createEffect, createMemo, createSignal, Show } from "solid-js";
 import { useZIndex } from "../../contexts/ZIndexContext";
+import { useModalRoute } from "../../lib/routing";
 import { cardSurfaceFlat } from "../../styles/containerStyles";
 import MarkdownRenderer from "../MarkdownRenderer";
+import Button from "./Button";
 import { Combobox } from "./Combobox";
 
 export interface SkillAttachmentSnapshot {
@@ -19,10 +21,12 @@ export interface SkillAttachmentsDialogProps {
   open: boolean;
   onClose: () => void;
   initialSkillName?: string | undefined;
+  workspaceId: string;
 }
 
 export const SkillAttachmentsDialog: Component<SkillAttachmentsDialogProps> = (props) => {
   const baseZIndex = useZIndex();
+  const { openModal } = useModalRoute();
   const [selectedSkillName, setSelectedSkillName] = createSignal<string | undefined>(
     props.initialSkillName || props.attachments[0]?.name,
   );
@@ -88,7 +92,19 @@ export const SkillAttachmentsDialog: Component<SkillAttachmentsDialogProps> = (p
                 <Show when={selectedAttachment()}>
                   {(attachment) => (
                     <div class="space-y-4">
-                      <h3 class="text-lg font-semibold text-heading">What Gets Sent to the LLM</h3>
+                      <div class="flex items-center justify-between gap-4">
+                        <h3 class="text-lg font-semibold text-heading">What Gets Sent to the LLM</h3>
+                        <Button
+                          variant="secondary"
+                          leftIcon={<LibraryBig size={16} />}
+                          onClick={() => {
+                            props.onClose();
+                            openModal("skill-library-v2", attachment().name);
+                          }}
+                        >
+                          Open in skill library
+                        </Button>
+                      </div>
                       <div class={`rounded-xl ${cardSurfaceFlat} overflow-hidden`}>
                         <div class="px-4 py-2 bg-surface-overlay border-b border-border-muted font-mono text-xs text-text-muted">
                           &lt;skill name="{attachment().name}"&gt;


### PR DESCRIPTION
## What's New

### Features
- Attached skills in chat bubbles now have an "Open in skill library" button. Click it to jump straight to the live skill in the Skills Library, where you can edit trigger phrases, open the skill folder in Finder, and see full metadata.

---

## Technical Changes

### Code Quality
- Added `workspaceId` prop to `SkillAttachmentsDialog` (required for library navigation)
- Wired `useModalRoute` into the dialog to open `skill-library-v2` pre-selected on the current skill

## Files Changed
- `SkillAttachmentsDialog.tsx` - button, `workspaceId` prop, modal routing
- `MessageBubble.tsx`, `ChatContainer.tsx`, `NewAgent.tsx` - pass `workspaceId` through (all three already had it from `useWorkspace()`)

## Testing
- Typecheck passes
- Button appears next to the "What Gets Sent to the LLM" heading and navigates to the correct skill in the library