### PR TITLE
CI: run checks on macOS

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -96,21 +96,6 @@ jobs:
           bun install --frozen-lockfile
           cd frontend && bun install --frozen-lockfile
 
-      - name: Debug frontend runtime
-        run: |
-          uname -m
-          arch
-          sw_vers
-          node -v
-          which node
-          bun --revision
-          bun -e 'console.log(JSON.stringify({processVersion: process.version, platform: process.platform, arch: process.arch, versions: process.versions}, null, 2))'
-          (
-            cd frontend
-            node -e 'console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
-            bun -e 'import { createRequire } from "module"; const require = createRequire(import.meta.url); console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
-          )
-
       - name: Run Tests
         run: cd frontend && bun run test
 

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   frontend-typecheck:
     name: Frontend TypeCheck
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -32,7 +32,7 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -55,7 +55,7 @@ jobs:
 
   frontend-css-lint:
     name: Frontend CSS Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -78,7 +78,7 @@ jobs:
 
   frontend-test:
     name: Frontend Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -101,7 +101,7 @@ jobs:
 
   frontend-build:
     name: Frontend Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -127,7 +127,7 @@ jobs:
 
   server-typecheck:
     name: Server TypeCheck
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -150,7 +150,7 @@ jobs:
 
   server-lint:
     name: Server Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -173,7 +173,7 @@ jobs:
 
   server-test:
     name: Server Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -196,7 +196,7 @@ jobs:
 
   server-build:
     name: Server Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse
@@ -219,7 +219,7 @@ jobs:
 
   plugin-typecheck:
     name: Plugin TypeCheck
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse-oc-plugin
@@ -240,7 +240,7 @@ jobs:
 
   plugin-test:
     name: Plugin Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse-oc-plugin
@@ -261,7 +261,7 @@ jobs:
 
   plugin-build:
     name: Plugin Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: projects/birdhouse-oc-plugin

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -96,6 +96,18 @@ jobs:
           bun install --frozen-lockfile
           cd frontend && bun install --frozen-lockfile
 
+      - name: Debug frontend runtime
+        run: |
+          uname -m
+          arch
+          sw_vers
+          node -v
+          which node
+          bun --revision
+          bun -e 'console.log(JSON.stringify({processVersion: process.version, platform: process.platform, arch: process.arch, versions: process.versions}, null, 2))'
+          cd frontend && node -e 'console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
+          cd frontend && bun -e 'import { createRequire } from "module"; const require = createRequire(import.meta.url); console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
+
       - name: Run Tests
         run: cd frontend && bun run test
 

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -105,8 +105,11 @@ jobs:
           which node
           bun --revision
           bun -e 'console.log(JSON.stringify({processVersion: process.version, platform: process.platform, arch: process.arch, versions: process.versions}, null, 2))'
-          cd frontend && node -e 'console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
-          cd frontend && bun -e 'import { createRequire } from "module"; const require = createRequire(import.meta.url); console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
+          (
+            cd frontend
+            node -e 'console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
+            bun -e 'import { createRequire } from "module"; const require = createRequire(import.meta.url); console.log(JSON.stringify({solid: require.resolve("solid-js"), store: require.resolve("solid-js/store")}, null, 2))'
+          )
 
       - name: Run Tests
         run: cd frontend && bun run test

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -123,6 +123,8 @@ jobs:
         run: cd frontend && bun run generate:themes && bun run validate:themes
 
       - name: Run Build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: cd frontend && bun run build
 
   server-typecheck:

--- a/projects/birdhouse/server/src/features/api/get-recent-agents.ts
+++ b/projects/birdhouse/server/src/features/api/get-recent-agents.ts
@@ -6,7 +6,6 @@ import type { Deps } from "../../dependencies";
 import type { Message } from "../../lib/opencode-client";
 
 // TODO(agent-search): Move search to db once we are setup for searching agents better
-const DAYS_LOOKBACK = 30;
 const MAX_SNIPPET_LENGTH = 200;
 
 interface RecentAgentResponse {

--- a/projects/birdhouse/server/src/lib/agents-db-migrations/run-agents-db-migrations.ts
+++ b/projects/birdhouse/server/src/lib/agents-db-migrations/run-agents-db-migrations.ts
@@ -87,7 +87,7 @@ export async function runAgentsDbMigrations(dbPath: string): Promise<void> {
  * Does NOT close the database — the caller retains ownership.
  */
 export async function runAgentsDbMigrationsOnDb(database: Database): Promise<void> {
-  const { migrator, db } = createAgentsMigratorFromDb(database);
+  const { migrator } = createAgentsMigratorFromDb(database);
   const resultSet = await migrator.migrateToLatest();
   logResults(resultSet.results);
   // Release Kysely's internal resources without closing the underlying connection.

--- a/projects/birdhouse/server/src/lib/opencode-manager.test.ts
+++ b/projects/birdhouse/server/src/lib/opencode-manager.test.ts
@@ -19,13 +19,20 @@ import { providersToEnv } from "./secrets";
 describe("OpenCodeManager environment configuration", () => {
   let dataDb: TestDataDB;
   let manager: OpenCodeManager;
+  let originalNodeEnv: string | undefined;
 
   beforeEach(() => {
     dataDb = new TestDataDB();
     manager = new OpenCodeManager(dataDb, "/test/opencode", 3000);
+    originalNodeEnv = process.env.NODE_ENV;
   });
 
   afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
     dataDb.close();
   });
 
@@ -386,6 +393,30 @@ describe("OpenCodeManager environment configuration", () => {
       expect(env.OPENCODE_DISABLE_PROJECT_CONFIG).toBe("true");
       expect(env.OPENCODE_DISABLE_CHANNEL_DB).toBe("true");
       expect(env.PORT).toBe("4310");
+    });
+
+    test("buildSpawnEnv does not forward launcher NODE_ENV to child processes", async () => {
+      process.env.NODE_ENV = "production";
+
+      const workspaceId = "ws_spawn_env_without_node_env";
+      dataDb.insertWorkspace({
+        workspace_id: workspaceId,
+        directory: "/test/path",
+        opencode_port: null,
+        opencode_pid: null,
+        created_at: new Date().toISOString(),
+        last_used: new Date().toISOString(),
+      });
+
+      const workspace = dataDb.getWorkspaceById(workspaceId);
+      const managerWithBuildEnv = manager as unknown as {
+        buildSpawnEnv: (workspace: object, port: number) => Promise<Record<string, string>>;
+      };
+
+      const env = await managerWithBuildEnv.buildSpawnEnv(workspace ?? {}, 4311);
+
+      expect(env.NODE_ENV).toBeUndefined();
+      expect(process.env.NODE_ENV).toBe("production");
     });
   });
 });

--- a/projects/birdhouse/server/src/lib/opencode-manager.ts
+++ b/projects/birdhouse/server/src/lib/opencode-manager.ts
@@ -321,15 +321,7 @@ export class OpenCodeManager {
     const proc = this.opencodeSourcePath
       ? spawn(
           "bun",
-          [
-            "run",
-            "--conditions=browser",
-            "src/index.ts",
-            "serve",
-            "--port",
-            port.toString(),
-            "--print-logs",
-          ],
+          ["run", "--conditions=browser", "src/index.ts", "serve", "--port", port.toString(), "--print-logs"],
           {
             cwd: join(this.opencodeSourcePath, "packages/opencode"),
             env,
@@ -753,8 +745,10 @@ export class OpenCodeManager {
       log.server.info({ workspaceId, port: instance.port, pid: instance.pid }, "Shutting down OpenCode from memory");
 
       if (instance.process) {
+        const proc = instance.process;
+
         // Send SIGTERM for graceful shutdown
-        instance.process.kill("SIGTERM");
+        proc.kill("SIGTERM");
 
         // Wait for graceful shutdown
         await new Promise<void>((resolve) => {
@@ -762,12 +756,12 @@ export class OpenCodeManager {
             // Force kill if still alive
             if (this.isProcessAlive(instance.pid)) {
               log.server.warn({ workspaceId, pid: instance.pid }, "OpenCode did not exit gracefully, force killing");
-              instance.process!.kill("SIGKILL");
+              proc.kill("SIGKILL");
             }
             resolve();
           }, 5000);
 
-          instance.process!.once("exit", () => {
+          proc.once("exit", () => {
             clearTimeout(timeout);
             resolve();
           });

--- a/projects/birdhouse/server/src/lib/opencode-manager.ts
+++ b/projects/birdhouse/server/src/lib/opencode-manager.ts
@@ -435,6 +435,7 @@ export class OpenCodeManager {
 
   private async buildSpawnEnv(workspace: Workspace, port: number): Promise<Record<string, string>> {
     const opencodeDataDir = getOpenCodeDataDir(workspace.workspace_id);
+    const { NODE_ENV: _nodeEnv, ...parentEnv } = process.env as Record<string, string>;
 
     if (!existsSync(opencodeDataDir)) {
       mkdirSync(opencodeDataDir, { recursive: true });
@@ -444,7 +445,7 @@ export class OpenCodeManager {
     const opencodeConfig = this.buildOpenCodeConfig(workspace);
 
     return {
-      ...(process.env as Record<string, string>),
+      ...parentEnv,
       ...workspaceEnv,
       OPENCODE_XDG_DATA_HOME: join(opencodeDataDir, "data"),
       OPENCODE_XDG_CONFIG_HOME: join(opencodeDataDir, "config"),


### PR DESCRIPTION
## Summary
- switch the CI checks workflow from ubuntu hosted runners to macOS hosted runners
- use this PR as the branch to iterate on any CI fallout until the full suite is green