### PR TITLE
Title generation: surface errors, set fallback title, fix last-turn extraction

### DIFF
--- a/projects/birdhouse/frontend/src/components/EditAgentDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/EditAgentDialog.tsx
@@ -22,12 +22,13 @@ export interface EditAgentDialogProps {
 
 /**
  * Extract the last "turn" from messages
- * A turn is all messages from and including the last user message
+ * A turn is all messages from and including the last user message.
+ * Messages are stored newest-first, so index 0 is the most recent.
  */
 function extractLastTurn(messages: Message[]): string {
-  // Find the last user message
+  // Find the most recent user message (first user message in newest-first array)
   let lastUserIndex = -1;
-  for (let i = messages.length - 1; i >= 0; i--) {
+  for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (msg && msg.role === "user") {
       lastUserIndex = i;
@@ -40,27 +41,16 @@ function extractLastTurn(messages: Message[]): string {
     return "";
   }
 
-  // Collect all messages from lastUserIndex onwards
-  const turnMessages = messages.slice(lastUserIndex);
+  // Collect all messages from the most recent user message back to index 0
+  // (index 0 is newest, so slice [0..lastUserIndex] gives the last turn)
+  const turnMessages = messages.slice(0, lastUserIndex + 1);
 
-  // Extract text content from each message
+  // Extract text content from each message.
+  // msg.content is the pre-concatenated plain text from all text parts.
   const textParts: string[] = [];
   for (const msg of turnMessages) {
-    // Add the simple content field
     if (msg.content?.trim()) {
       textParts.push(`[${msg.role}]: ${msg.content.trim()}`);
-    }
-
-    // Also check blocks for text content
-    if (msg.blocks) {
-      for (const block of msg.blocks) {
-        if (block.type === "text" && "content" in block && typeof block.content === "string") {
-          const content = block.content.trim();
-          if (content) {
-            textParts.push(`[${msg.role}]: ${content}`);
-          }
-        }
-      }
     }
   }
 

--- a/projects/birdhouse/frontend/src/components/EditAgentDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/EditAgentDialog.tsx
@@ -182,7 +182,9 @@ const EditAgentDialog: Component<EditAgentDialogProps> = (props) => {
 
           {/* Error Message */}
           <Show when={error()}>
-            <div class="mb-4 text-danger text-sm p-3 bg-surface-raised rounded-lg border border-danger">{error()}</div>
+            <div class="mb-4 text-danger text-sm p-3 bg-surface-raised rounded-lg border border-danger break-words">
+              {error()}
+            </div>
           </Show>
 
           {/* Actions */}

--- a/projects/birdhouse/server/src/features/api/create.ts
+++ b/projects/birdhouse/server/src/features/api/create.ts
@@ -255,6 +255,7 @@ async function generateAndUpdateTitle(
     // Call title generation service directly (no HTTP request needed)
     const result = await generateTitleService(deps, {
       message: message.trim(),
+      workspaceId: _workspaceId,
     });
 
     const generatedTitle = result.title;

--- a/projects/birdhouse/server/src/features/api/create.ts
+++ b/projects/birdhouse/server/src/features/api/create.ts
@@ -165,8 +165,23 @@ export async function create(c: Context, deps: Pick<Deps, "opencode" | "agentsDB
                 agentId: agent.id,
                 error: error instanceof Error ? error.message : "Unknown error",
               },
-              "Failed to generate title",
+              "Failed to generate title — setting fallback title",
             );
+            // Clear the "Creating Agent..." placeholder so the agent isn't stuck
+            const fallbackTitle = prompt.trim().slice(0, 60) || "New Agent";
+            syncAgentTitle(
+              { agentsDB: deps.agentsDB, opencodeClient: deps.opencode, opencodeBase, workspaceDir, log },
+              agent.id,
+              fallbackTitle,
+            ).catch((syncError) => {
+              log.server.error(
+                {
+                  agentId: agent.id,
+                  error: syncError instanceof Error ? syncError.message : "Unknown error",
+                },
+                "Failed to set fallback title",
+              );
+            });
           });
         }
 

--- a/projects/birdhouse/server/src/features/api/generate-title.ts
+++ b/projects/birdhouse/server/src/features/api/generate-title.ts
@@ -15,6 +15,7 @@ export async function generateTitle(c: Context, deps: Pick<Deps, "opencode" | "l
     // Parse and validate request body
     const body = await c.req.json();
     const { message, source_agent_title } = body;
+    const workspace = c.get("workspace");
 
     // Validate required fields
     if (!message || typeof message !== "string" || message.trim() === "") {
@@ -33,6 +34,7 @@ export async function generateTitle(c: Context, deps: Pick<Deps, "opencode" | "l
     const result = await generateTitleService(deps, {
       message: message.trim(),
       sourceAgentTitle: source_agent_title?.trim(),
+      workspaceId: workspace?.workspace_id,
     });
 
     // Return generated title

--- a/projects/birdhouse/server/src/lib/title-generator.test.ts
+++ b/projects/birdhouse/server/src/lib/title-generator.test.ts
@@ -7,6 +7,26 @@ import { buildTitleMessage, TITLE_PROMPT } from "./prompts/title-prompt";
 import { generateTitle } from "./title-generator";
 
 describe("title-generator", () => {
+  it("throws an error when LLM returns an empty string", async () => {
+    const deps = await createTestDeps({
+      generate: async () => "",
+    });
+
+    await expect(generateTitle(deps, { message: "Do something" })).rejects.toThrow(
+      "Title generation returned empty response",
+    );
+  });
+
+  it("throws an error when LLM returns a whitespace-only string", async () => {
+    const deps = await createTestDeps({
+      generate: async () => "   ",
+    });
+
+    await expect(generateTitle(deps, { message: "Do something" })).rejects.toThrow(
+      "Title generation returned empty response",
+    );
+  });
+
   it("uses the dedicated title prompt file directly", async () => {
     let capturedOptions:
       | {

--- a/projects/birdhouse/server/src/lib/title-generator.ts
+++ b/projects/birdhouse/server/src/lib/title-generator.ts
@@ -2,11 +2,13 @@
 // ABOUTME: Applies Birdhouse-owned title rules from a dedicated prompt file.
 
 import type { Deps } from "../dependencies";
+import { getOpenCodeDataDir } from "./database-paths";
 import { buildTitleMessage, TITLE_PROMPT } from "./prompts/title-prompt";
 
 export interface TitleGenerationOptions {
   message: string;
   sourceAgentTitle?: string;
+  workspaceId?: string;
 }
 
 export interface TitleGenerationResult {
@@ -28,7 +30,7 @@ export async function generateTitle(
     log,
   } = deps;
 
-  const { message, sourceAgentTitle } = options;
+  const { message, sourceAgentTitle, workspaceId } = options;
 
   // Build system instructions for clone context
   const systemInstructions: string[] = [];
@@ -58,14 +60,19 @@ export async function generateTitle(
     });
 
     if (!title || title.trim() === "") {
+      const modelJsonPath = workspaceId
+        ? `${getOpenCodeDataDir(workspaceId)}/state/opencode/model.json`
+        : "<workspace>/engine/state/opencode/model.json";
       const err = new Error(
-        "Title generation returned empty response — the active model may not support this prompt. " +
-          "Check OpenCode logs for the model being used (search: service=llm path=/llm/generate).",
+        "Title generation returned empty response. The active model may not support this prompt.\n" +
+          `This may be caused by a bad default model in: ${modelJsonPath}\n` +
+          "Check logs for the model being used (search: service=llm path=/llm/generate).",
       );
       log.server.error(
         {
           sourceAgentTitle,
-          hint: "Check which model is selected as 'small' for this workspace in OpenCode logs",
+          modelJsonPath,
+          hint: "Delete or clear the 'recent' array in model.json to reset the default model",
         },
         "TITLE_GENERATION_EMPTY: LLM returned empty title",
       );

--- a/projects/birdhouse/server/src/lib/title-generator.ts
+++ b/projects/birdhouse/server/src/lib/title-generator.ts
@@ -57,6 +57,21 @@ export async function generateTitle(
       maxTokens: 300,
     });
 
+    if (!title || title.trim() === "") {
+      const err = new Error(
+        "Title generation returned empty response — the active model may not support this prompt. " +
+          "Check OpenCode logs for the model being used (search: service=llm path=/llm/generate).",
+      );
+      log.server.error(
+        {
+          sourceAgentTitle,
+          hint: "Check which model is selected as 'small' for this workspace in OpenCode logs",
+        },
+        "TITLE_GENERATION_EMPTY: LLM returned empty title",
+      );
+      throw err;
+    }
+
     log.server.debug({ title }, "Title generated successfully");
 
     return {


### PR DESCRIPTION
## What's New

### 🐛 Fixes
- **Title generation no longer silently fails** — when the LLM returns an empty response (e.g. a model that doesn't support the title prompt), an error is now thrown and surfaced in the UI with a clear message
- **Agents no longer get stuck on "Creating Agent..."** — if auto-title generation fails, the agent title is now set to the first 60 chars of the prompt as a fallback instead of staying on the placeholder forever
- **"Generate" button in Edit Agent dialog now uses the most recent exchange** — was incorrectly reading the oldest user message due to messages being stored newest-first; now correctly uses the last turn

## Technical Changes

### 🏗️ Infrastructure
- `TitleGenerationOptions` gains an optional `workspaceId` field; when present, the error message includes the exact path to `model.json` (the file that controls OpenCode's default model selection) so the user knows exactly what to fix
- Fallback title is set via `syncAgentTitle` on the existing `.catch()` path in `create.ts`, so the SSE event fires and the UI updates reactively
- Removed duplicate text extraction in `extractLastTurn` — `msg.content` already contains concatenated plain text from all text parts, so the `blocks` loop was redundant

### 🧹 Code Quality
- Error message includes a greppable tag (`TITLE_GENERATION_EMPTY`) and a structured log field pointing at `model.json` with a hint to delete or clear `recent`

## Testing
- Added two new unit tests in `title-generator.test.ts`: empty string response and whitespace-only response both throw with the expected message
- Full server suite: 604 pass, 0 fail
- Full frontend suite: typecheck + lint clean
- Manually reproduced the empty-title failure in `ws_4d9963224c5bcf0d` (fireworks-ai/kimi-k2p5 as small model) and confirmed the error message displays correctly in the Edit Agent dialog