### PR TITLE
Context usage indicator: fix cache miss, missing limit data, and unknown-limit display

### DIFF
--- a/projects/birdhouse/frontend/src/components/AgentHeader.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentHeader.tsx
@@ -297,13 +297,15 @@ export const AgentHeader: Component<AgentHeaderProps> = (props) => {
         <div class="content-wrapper">
           {/* Left zone: donut + title — flex-1 so it fills remaining space and title can truncate */}
           <div class="flex items-center gap-3 flex-1 min-w-0 overflow-hidden">
-            {/* Context Usage Donut Indicator */}
-            <ContextUsageIndicator
-              percentage={percentage()}
-              model={tokenStats().model}
-              limit={tokenStats().limit}
-              used={tokenStats().used}
-            />
+            {/* Context Usage Donut Indicator — hidden when limit is unknown (0) */}
+            <Show when={tokenStats().limit > 0}>
+              <ContextUsageIndicator
+                percentage={percentage()}
+                model={tokenStats().model}
+                limit={tokenStats().limit}
+                used={tokenStats().used}
+              />
+            </Show>
 
             {/* Title - truncates when the container is too narrow */}
             <span

--- a/projects/birdhouse/frontend/src/stores/model-limits.test.ts
+++ b/projects/birdhouse/frontend/src/stores/model-limits.test.ts
@@ -2,12 +2,13 @@
 // ABOUTME: Validates fetching and caching behavior for model context limits
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { fetchModelLimits, getModelLimit } from "./model-limits";
+import { clearModelLimitsCache, fetchModelLimits, getModelLimit } from "./model-limits";
 
 describe("model-limits store", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(globalThis, "fetch");
+    clearModelLimitsCache();
   });
 
   describe("fetchModelLimits", () => {
@@ -78,7 +79,10 @@ describe("model-limits store", () => {
       expect(getModelLimit("anthropic/claude-sonnet-4-5")).toBe(200_000);
     });
 
-    test("should lookup by model name when given provider/model format", async () => {
+    test("should find model by bare name when cache contains provider/model IDs", async () => {
+      // opencode message.modelID is the bare name (e.g. "claude-sonnet-4-6"),
+      // but the models API returns full "provider/model" IDs.
+      // Both lookup formats must work.
       const mockModels = [
         {
           id: "anthropic/claude-sonnet-4-5",
@@ -96,8 +100,10 @@ describe("model-limits store", () => {
 
       await fetchModelLimits(TEST_WORKSPACE_ID);
 
-      // Should find by full ID
+      // Full ID lookup
       expect(getModelLimit("anthropic/claude-sonnet-4-5")).toBe(200_000);
+      // Bare name lookup (how message.modelID arrives from opencode)
+      expect(getModelLimit("claude-sonnet-4-5")).toBe(200_000);
     });
 
     test("should return undefined for unknown models", async () => {

--- a/projects/birdhouse/frontend/src/stores/model-limits.ts
+++ b/projects/birdhouse/frontend/src/stores/model-limits.ts
@@ -31,7 +31,16 @@ export async function fetchModelLimits(workspaceId: string): Promise<void> {
 
   modelLimitsCache.clear();
   for (const model of models) {
+    // Store by full "provider/model" ID
     modelLimitsCache.set(model.id, model.contextLimit);
+    // Also store by bare model name so lookups with just the model ID work
+    // (message.modelID from opencode is the bare name, not the full provider/model ID)
+    if (model.id.includes("/")) {
+      const bareName = model.id.split("/")[1];
+      if (bareName) {
+        modelLimitsCache.set(bareName, model.contextLimit);
+      }
+    }
   }
 }
 
@@ -43,20 +52,12 @@ export async function fetchModelLimits(workspaceId: string): Promise<void> {
  * @returns Context limit in tokens, or undefined if not found
  */
 export function getModelLimit(modelId: string): number | undefined {
-  // Try cache with full ID
-  const fullIdResult = modelLimitsCache.get(modelId);
-  if (fullIdResult !== undefined) {
-    return fullIdResult;
-  }
+  return modelLimitsCache.get(modelId);
+}
 
-  // Extract model name from "provider/model" format if present
-  const modelName = modelId.includes("/") ? modelId.split("/")[1] : modelId;
-
-  // Try cache with just model name
-  if (modelName) {
-    return modelLimitsCache.get(modelName);
-  }
-
-  // Not found
-  return undefined;
+/**
+ * Clear the model limits cache (for testing)
+ */
+export function clearModelLimitsCache(): void {
+  modelLimitsCache.clear();
 }

--- a/projects/birdhouse/server/src/harness/opencode-type-mappers.test.ts
+++ b/projects/birdhouse/server/src/harness/opencode-type-mappers.test.ts
@@ -330,4 +330,42 @@ describe("opencode type mappers", () => {
     };
     expect(mapOpenCodeQuestionRequestToBirdhouseQuestionRequest(question)).toEqual(question);
   });
+
+  it("preserves model limit through OpenCode-to-Birdhouse provider mapping", () => {
+    const withLimit = {
+      providers: [
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          models: {
+            "claude-sonnet-4-6": {
+              id: "claude-sonnet-4-6",
+              name: "Claude Sonnet 4.6",
+              limit: { context: 200_000, output: 64_000 },
+            },
+          },
+        },
+      ],
+    };
+
+    const mapped = mapOpenCodeProvidersResponseToBirdhouseProvidersResponse(withLimit);
+    expect(mapped.providers[0].models["claude-sonnet-4-6"].limit).toEqual({ context: 200_000, output: 64_000 });
+  });
+
+  it("omits limit when not present in OpenCode provider model", () => {
+    const withoutLimit = {
+      providers: [
+        {
+          id: "custom",
+          name: "Custom",
+          models: {
+            "some-model": { id: "some-model", name: "Some Model" },
+          },
+        },
+      ],
+    };
+
+    const mapped = mapOpenCodeProvidersResponseToBirdhouseProvidersResponse(withoutLimit);
+    expect(mapped.providers[0].models["some-model"].limit).toBeUndefined();
+  });
 });

--- a/projects/birdhouse/server/src/harness/opencode-type-mappers.ts
+++ b/projects/birdhouse/server/src/harness/opencode-type-mappers.ts
@@ -224,7 +224,14 @@ export function mapOpenCodeProvidersResponseToBirdhouseProvidersResponse(
       id: provider.id,
       name: provider.name,
       models: Object.fromEntries(
-        Object.entries(provider.models).map(([key, model]) => [key, { id: model.id, name: model.name }]),
+        Object.entries(provider.models).map(([key, model]) => [
+          key,
+          {
+            id: model.id,
+            name: model.name,
+            ...(model.limit !== undefined ? { limit: { context: model.limit.context, output: model.limit.output } } : {}),
+          },
+        ]),
       ),
     })),
   };

--- a/projects/birdhouse/server/src/harness/opencode-type-mappers.ts
+++ b/projects/birdhouse/server/src/harness/opencode-type-mappers.ts
@@ -229,7 +229,9 @@ export function mapOpenCodeProvidersResponseToBirdhouseProvidersResponse(
           {
             id: model.id,
             name: model.name,
-            ...(model.limit !== undefined ? { limit: { context: model.limit.context, output: model.limit.output } } : {}),
+            ...(model.limit !== undefined
+              ? { limit: { context: model.limit.context, output: model.limit.output } }
+              : {}),
           },
         ]),
       ),

--- a/projects/birdhouse/server/src/harness/types.ts
+++ b/projects/birdhouse/server/src/harness/types.ts
@@ -41,6 +41,10 @@ export interface BirdhouseModelRef {
 export interface BirdhouseProviderModel {
   id: string;
   name: string;
+  limit?: {
+    context: number;
+    output: number;
+  };
 }
 
 export interface BirdhouseProvider {

--- a/projects/birdhouse/server/src/lib/opencode-client.ts
+++ b/projects/birdhouse/server/src/lib/opencode-client.ts
@@ -63,7 +63,7 @@ export interface QuestionRequest {
 export interface Provider {
   id: string;
   name: string;
-  models: Record<string, { id: string; name: string }>;
+  models: Record<string, { id: string; name: string; limit?: { context: number; output: number } }>;
 }
 
 export interface ProvidersResponse {

--- a/projects/birdhouse/server/src/routes/models.test.ts
+++ b/projects/birdhouse/server/src/routes/models.test.ts
@@ -72,7 +72,9 @@ describe("GET /api/models", () => {
     });
   });
 
-  test("should use default contextLimit of 200_000 when limit is missing", async () => {
+  test("should use contextLimit of 0 when limit is missing (unknown limit)", async () => {
+    // Models without a limit from opencode get contextLimit=0, meaning unknown.
+    // The frontend hides the context indicator when limit=0.
     const mockProviders = {
       providers: [
         {
@@ -111,9 +113,43 @@ describe("GET /api/models", () => {
         id: "custom-provider/custom-model",
         name: "Custom Model",
         provider: "Custom Provider",
-        contextLimit: 200_000,
+        contextLimit: 0,
         outputLimit: 0,
       });
+    });
+  });
+
+  test("should use contextLimit of 0 when opencode reports limit.context=0 (unknown limit)", async () => {
+    // opencode returns limit.context=0 for models it has no context data for.
+    // We treat this the same as missing — 0 means unknown, not actually 0 tokens.
+    const mockProviders = {
+      providers: [
+        {
+          id: "some-provider",
+          name: "Some Provider",
+          models: {
+            "some-model": {
+              id: "some-model",
+              name: "Some Model",
+              limit: { context: 0, output: 0 },
+            },
+          },
+        },
+      ],
+    };
+
+    const deps = await createTestDeps();
+    deps.harness.getProviders = async () => mockProviders as never;
+
+    await withDeps(deps, async () => {
+      const app = await withWorkspaceContext(createModelRoutes);
+      const req = new Request("http://localhost/");
+      const res = await app.fetch(req);
+
+      expect(res.status).toBe(200);
+
+      const models = (await res.json()) as Array<{ contextLimit: number }>;
+      expect(models[0].contextLimit).toBe(0);
     });
   });
 

--- a/projects/birdhouse/server/src/routes/models.ts
+++ b/projects/birdhouse/server/src/routes/models.ts
@@ -59,11 +59,15 @@ export function createModelRoutes() {
       const models: Model[] = [];
       for (const provider of providers) {
         for (const [modelId, modelInfo] of Object.entries(provider.models)) {
+          // Use opencode's limit when present and non-zero.
+          // A context of 0 means opencode has no limit data for this model.
+          const contextLimit =
+            modelInfo.limit?.context != null && modelInfo.limit.context > 0 ? modelInfo.limit.context : 0;
           models.push({
             id: `${provider.id}/${modelId}`,
             name: modelInfo.name || modelId,
             provider: provider.name || provider.id,
-            contextLimit: modelInfo.limit?.context ?? 200_000,
+            contextLimit,
             outputLimit: modelInfo.limit?.output ?? 0,
           });
         }


### PR DESCRIPTION
## 🐛 Fixes

- **Context usage donut now shows correctly for all models.** Three compounding bugs caused the indicator to show wrong percentages (0%, stale 200k denominator, or >100%): a cache key mismatch, the model limit being stripped in the mapper pipeline, and a bad fallback for models where opencode reports no context limit.
- **Donut is hidden for models with unknown context limits** rather than displaying a misleading percentage against an incorrect denominator.

---

## Technical Changes

### Root causes fixed

**1. Cache key mismatch** (`model-limits.ts`)
The cache was keyed by full `provider/model` IDs (e.g. `anthropic/claude-sonnet-4-6`), but `getModelLimit` was called with the bare model name (`claude-sonnet-4-6`) from `message.modelID` in opencode. Every lookup missed. Fix: store both the full ID and bare name when populating the cache; simplify `getModelLimit` to a direct map lookup.

**2. `limit` stripped by mapper** (`opencode-type-mappers.ts`, `types.ts`, `opencode-client.ts`)
`mapOpenCodeProvidersResponseToBirdhouseProvidersResponse` only forwarded `id` and `name`, silently dropping the `limit` field. Neither `BirdhouseProviderModel` nor the `Provider` interface in `opencode-client.ts` included `limit`. Every model fell back to 200k. Fix: add `limit` to both types and pass it through the mapper.

**3. Wrong fallback for unknown limits** (`models.ts`)
`modelInfo.limit?.context ?? 200_000` applied a 200k fallback to models where opencode explicitly returns `limit.context = 0` (meaning "no data"). Heavy sessions with >200k tokens then showed >100%. Fix: treat `limit.context = 0` and absent `limit` the same — `contextLimit: 0`. The frontend now hides the donut when `limit = 0`.

## Testing

- Added a test for bare-name cache lookup in `model-limits.test.ts`
- Added tests for `limit=0` and missing-limit behavior in `models.test.ts`
- Added mapper tests verifying `limit` is preserved and omitted correctly in `opencode-type-mappers.test.ts`
- All CI checks pass (677 frontend tests, 662 server tests, plugin build)