### PR TITLE
Agent search: fast recent list with lazy per-card snippet loading

### DIFF
--- a/projects/birdhouse/docs/code-review/testing.md
+++ b/projects/birdhouse/docs/code-review/testing.md
@@ -30,15 +30,60 @@ createEffect(() => {
 
 ---
 
-## Coming Soon
+## Corvu Component Mocks Are Load-Bearing
 
-This guide will cover:
-- Component testing patterns
-- Testing user interactions
-- Snapshot testing
-- Mock strategies
+When a Corvu primitive (Dialog, Popover, Drawer, etc.) is mocked in a test file, the mock's
+prop interface becomes part of the test infrastructure. If the real component adds a new event
+handler prop — `onKeyUp`, `onFocus`, `onPointerDown`, etc. — and the mock doesn't forward it,
+the handler silently disappears. The test won't fail with a clear error; it will just never fire.
 
-**For now, see:**
-- `src/components/ui/Button.test.tsx` - Example component test
-- `src/workspace-config/components/WorkspaceConfigDialog.test.tsx` - Resource error testing
-- Run: `bun run test` or `bun run test:watch`
+**Symptom:** You add a new event handler to a Corvu component in production code. Tests that
+exercise that handler pass zero calls to the mock function, even though the handler works in
+the browser.
+
+**Cause:** The mock `Dialog.Content` (or equivalent) only forwards the props it was originally
+written to accept. New props are ignored unless explicitly added.
+
+**Fix:** Keep the mock's prop type in sync with what the component actually uses. When you add
+a handler to `Dialog.Content` in the component, add the same prop to the mock:
+
+```tsx
+// In the test file's vi.mock("corvu/dialog", ...) block:
+Dialog.Content = (props: {
+  children: JSX.Element;
+  class?: string;
+  onKeyDown?: (e: KeyboardEvent) => void;
+  onKeyUp?: (e: KeyboardEvent) => void;  // ← add when component uses it
+}) => (
+  <div role="presentation" onKeyDown={props.onKeyDown} onKeyUp={props.onKeyUp}>
+    {props.children}
+  </div>
+);
+```
+
+The mock in `AgentSearchDialog.test.tsx` is the canonical reference for this pattern.
+
+---
+
+## Test Helper Side Effects
+
+Test files often define small helpers like `renderDialog()` that set up shared mutable state
+before rendering. If that helper resets state you've already configured, tests silently use the
+wrong setup.
+
+**Symptom:** You set a shared variable (e.g. `mockModalStack`) before calling a render helper,
+but the test behaves as if your assignment never happened.
+
+**Cause:** The render helper resets the variable as a side effect.
+
+**Fix:** Document the side effects on the helper, and in tests that need non-default state,
+set the variable *after* calling the helper:
+
+```ts
+// renderDialog resets mockModalStack as a side effect — set it after if needed
+renderDialog();
+mockModalStack = [{ type: "agent-search", id: "main" }, { type: "agent", id: "agent-1" }];
+await screen.findByLabelText("Search agent messages");
+```
+
+See `AgentSearchDialog.test.tsx` for a working example of both patterns.

--- a/projects/birdhouse/frontend/src/components/AgentModal.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentModal.tsx
@@ -50,6 +50,11 @@ const AgentModal: Component<AgentModalProps> = (props) => {
             "max-width": `calc(1792px - ${sizeReduction}px)`,
             "z-index": baseZIndex + 2,
           }}
+          onKeyUp={(e: KeyboardEvent) => {
+            if (e.code === "ShiftRight" && !e.metaKey && !e.ctrlKey && !e.altKey && props.isTop) {
+              props.onClose();
+            }
+          }}
         >
           {/* Provide increased z-index context to children (dialogs, popovers) */}
           <ZIndexProvider baseZIndex={baseZIndex + 10}>

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -427,20 +427,6 @@ describe("AgentSearchDialog", () => {
       await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-1"));
     });
 
-    it("Right Shift dismisses the peek when an agent modal is already on top", async () => {
-      // Render with an agent modal already on top — set stack after renderDialog resets it
-      renderDialog();
-      mockModalStack = [
-        { type: "agent-search", id: "main" },
-        { type: "agent", id: "agent-1" },
-      ];
-      await screen.findByLabelText("Search agent messages");
-      const content = screen.getByRole("presentation");
-      fireEvent.keyUp(content, { code: "ShiftRight", key: "Shift" });
-      await waitFor(() => expect(mockCloseModal).toHaveBeenCalled());
-      expect(mockOpenModal).not.toHaveBeenCalled();
-    });
-
     it("scrolls the active search result into view during keyboard navigation", async () => {
       await renderWithResults();
       const input = screen.getByLabelText("Search agent messages");

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -45,9 +45,14 @@ vi.mock("corvu/dialog", () => {
   );
   Dialog.Portal = (props: { children: JSX.Element }) => <>{props.children}</>;
   Dialog.Overlay = () => null;
-  Dialog.Content = (props: { children: JSX.Element; class?: string; onKeyDown?: (e: KeyboardEvent) => void }) => (
+  Dialog.Content = (props: {
+    children: JSX.Element;
+    class?: string;
+    onKeyDown?: (e: KeyboardEvent) => void;
+    onKeyUp?: (e: KeyboardEvent) => void;
+  }) => (
     // biome-ignore lint/a11y/noStaticElementInteractions: test mock — not a real interactive element
-    <div role="presentation" class={props.class} onKeyDown={props.onKeyDown}>
+    <div role="presentation" class={props.class} onKeyDown={props.onKeyDown} onKeyUp={props.onKeyUp}>
       {props.children}
     </div>
   );
@@ -406,11 +411,19 @@ describe("AgentSearchDialog", () => {
       });
     });
 
-    it("Enter with an active result opens agent in modal", async () => {
+    it("Enter with an active result navigates directly to the agent", async () => {
       await renderWithResults();
       const input = screen.getByLabelText("Search agent messages");
       fireEvent.keyDown(input, { key: "ArrowDown" });
       fireEvent.keyDown(input, { key: "Enter" });
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/workspace/test-workspace/agent/agent-1"));
+    });
+
+    it("Right Shift with an active result peeks the agent in a modal", async () => {
+      await renderWithResults();
+      const content = screen.getByRole("presentation");
+      fireEvent.keyDown(content, { key: "ArrowDown" });
+      fireEvent.keyUp(content, { code: "ShiftRight", key: "Shift" });
       await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-1"));
     });
 
@@ -423,22 +436,6 @@ describe("AgentSearchDialog", () => {
       await waitFor(() => {
         expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
       });
-    });
-
-    it("Cmd+Enter with an active result navigates directly to the agent", async () => {
-      await renderWithResults();
-      const input = screen.getByLabelText("Search agent messages");
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-      fireEvent.keyDown(input, { key: "Enter", metaKey: true });
-      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/workspace/test-workspace/agent/agent-1"));
-    });
-
-    it("Ctrl+Enter with an active result navigates directly to the agent", async () => {
-      await renderWithResults();
-      const input = screen.getByLabelText("Search agent messages");
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-      fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
-      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/workspace/test-workspace/agent/agent-1"));
     });
 
     it("ArrowDown wraps from last result to first", async () => {
@@ -469,7 +466,7 @@ describe("AgentSearchDialog", () => {
       const input = screen.getByLabelText("Search agent messages");
       // No ArrowDown pressed — index stays at -1
       fireEvent.keyDown(input, { key: "Enter" });
-      expect(mockOpenModal).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it("active index resets to -1 when a new search is triggered", async () => {
@@ -503,11 +500,20 @@ describe("AgentSearchDialog", () => {
       });
     });
 
-    it("Enter with an active recent agent opens it in a modal", async () => {
+    it("Enter with an active recent agent navigates directly", async () => {
       await renderWithRecentAgents();
       const input = screen.getByLabelText("Search agent messages");
       fireEvent.keyDown(input, { key: "ArrowDown" });
       fireEvent.keyDown(input, { key: "Enter" });
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/workspace/test-workspace/agent/agent-recent-1"));
+    });
+
+    it("Right Shift with an active recent agent peeks it in a modal", async () => {
+      await renderWithRecentAgents();
+      const content = screen.getByRole("presentation");
+      fireEvent.keyDown(content, { key: "ArrowDown" });
+      fireEvent.keyUp(content, { code: "ShiftRight", key: "Shift" });
 
       await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-recent-1"));
     });
@@ -521,15 +527,6 @@ describe("AgentSearchDialog", () => {
       await waitFor(() => {
         expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
       });
-    });
-
-    it("Cmd+Enter with an active recent agent navigates directly", async () => {
-      await renderWithRecentAgents();
-      const input = screen.getByLabelText("Search agent messages");
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-      fireEvent.keyDown(input, { key: "Enter", metaKey: true });
-
-      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/workspace/test-workspace/agent/agent-recent-1"));
     });
   });
 });

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -59,6 +59,7 @@ vi.mock("corvu/dialog", () => {
 
 const mockSearchAgentMessages = agentsApi.searchAgentMessages as ReturnType<typeof vi.fn>;
 const mockFetchRecentAgents = agentsApi.fetchRecentAgents as ReturnType<typeof vi.fn>;
+const scrollIntoViewMock = vi.fn();
 
 const makeResponse = (results: AgentMessageSearchResponse["results"]): AgentMessageSearchResponse => ({
   results,
@@ -106,11 +107,17 @@ const renderDialog = (open = true) => {
 
 describe("AgentSearchDialog", () => {
   beforeEach(() => {
+    scrollIntoViewMock.mockReset();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
     mockFetchRecentAgents.mockResolvedValue([]);
     mockSearchAgentMessages.mockResolvedValue(makeResponse([]));
   });
 
   afterEach(() => {
+    delete (window.HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView;
     vi.clearAllMocks();
   });
 
@@ -234,6 +241,17 @@ describe("AgentSearchDialog", () => {
       await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-1"));
     });
 
+    it("scrolls the active search result into view during keyboard navigation", async () => {
+      await renderWithResults();
+      const input = screen.getByLabelText("Search agent messages");
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      await waitFor(() => {
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+      });
+    });
+
     it("Cmd+Enter with an active result navigates directly to the agent", async () => {
       await renderWithResults();
       const input = screen.getByLabelText("Search agent messages");
@@ -319,6 +337,17 @@ describe("AgentSearchDialog", () => {
       fireEvent.keyDown(input, { key: "Enter" });
 
       await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-recent-1"));
+    });
+
+    it("scrolls the active recent agent into view during keyboard navigation", async () => {
+      await renderWithRecentAgents();
+      const input = screen.getByLabelText("Search agent messages");
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      await waitFor(() => {
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+      });
     });
 
     it("Cmd+Enter with an active recent agent navigates directly", async () => {

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -126,11 +126,11 @@ describe("AgentSearchDialog", () => {
     expect(screen.getByLabelText("Search agent messages")).toBeInTheDocument();
   });
 
-  it("fetches and shows recent agents immediately on open", async () => {
+  it("fetches recent agents with limit=50 immediately on open", async () => {
     renderDialog();
 
     await waitFor(() => {
-      expect(mockFetchRecentAgents).toHaveBeenCalledWith("test-workspace");
+      expect(mockFetchRecentAgents).toHaveBeenCalledWith("test-workspace", undefined, 50);
     });
   });
 
@@ -142,9 +142,9 @@ describe("AgentSearchDialog", () => {
     expect(screen.getByText("Recent Agent")).toBeInTheDocument();
   });
 
-  it("caps recent agents at 100 items", async () => {
+  it("renders all agents returned by fetchRecentAgents (limit enforced server-side)", async () => {
     mockFetchRecentAgents.mockResolvedValue(
-      Array.from({ length: 101 }, (_, index) =>
+      Array.from({ length: 50 }, (_, index) =>
         makeRecentAgent({
           id: `agent-recent-${index + 1}`,
           session_id: `ses-recent-${index + 1}`,
@@ -155,8 +155,7 @@ describe("AgentSearchDialog", () => {
     );
     renderDialog();
 
-    expect(await screen.findByText("Recent Agent 100")).toBeInTheDocument();
-    expect(screen.queryByText("Recent Agent 101")).not.toBeInTheDocument();
+    expect(await screen.findByText("Recent Agent 50")).toBeInTheDocument();
   });
 
   it("shows the keyboard hint footer", () => {

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -427,6 +427,20 @@ describe("AgentSearchDialog", () => {
       await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-1"));
     });
 
+    it("Right Shift dismisses the peek when an agent modal is already on top", async () => {
+      // Render with an agent modal already on top — set stack after renderDialog resets it
+      renderDialog();
+      mockModalStack = [
+        { type: "agent-search", id: "main" },
+        { type: "agent", id: "agent-1" },
+      ];
+      await screen.findByLabelText("Search agent messages");
+      const content = screen.getByRole("presentation");
+      fireEvent.keyUp(content, { code: "ShiftRight", key: "Shift" });
+      await waitFor(() => expect(mockCloseModal).toHaveBeenCalled());
+      expect(mockOpenModal).not.toHaveBeenCalled();
+    });
+
     it("scrolls the active search result into view during keyboard navigation", async () => {
       await renderWithResults();
       const input = screen.getByLabelText("Search agent messages");

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -1,10 +1,10 @@
 // ABOUTME: Tests for AgentSearchDialog component
 // ABOUTME: Verifies open/close, idle state, debounce API call, result rendering, and keyboard nav
 
-import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import type { JSX } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentMessageSearchResponse, RecentAgentForTypeahead } from "../services/agents-api";
+import type { AgentMessageSearchResponse, RecentAgentForTypeahead, RecentAgentSnippet } from "../services/agents-api";
 import * as agentsApi from "../services/agents-api";
 import AgentSearchDialog from "./AgentSearchDialog";
 
@@ -13,21 +13,23 @@ vi.mock("../contexts/WorkspaceContext", () => ({
 }));
 
 vi.mock("../services/agents-api", () => ({
-  fetchRecentAgents: vi.fn(),
+  fetchRecentAgentsList: vi.fn(),
+  fetchRecentAgentSnippet: vi.fn(),
   searchAgentMessages: vi.fn(),
 }));
 
-// Control open state via the modal route mock
-let mockIsOpen = true;
+// Control modal stack via the route mock
+let mockModalStack = [{ type: "agent-search", id: "main" }];
 const mockCloseModal = vi.fn();
 const mockOpenModal = vi.fn();
 const mockNavigate = vi.fn();
+const mockRemoveModalByType = vi.fn();
 
 vi.mock("../lib/routing", () => ({
   useModalRoute: () => ({
-    modalStack: () => (mockIsOpen ? [{ type: "agent-search", id: "main" }] : []),
+    modalStack: () => mockModalStack,
     closeModal: mockCloseModal,
-    removeModalByType: vi.fn(),
+    removeModalByType: mockRemoveModalByType,
     openModal: mockOpenModal,
   }),
   useWorkspaceId: () => () => "test-workspace",
@@ -58,8 +60,46 @@ vi.mock("corvu/dialog", () => {
 });
 
 const mockSearchAgentMessages = agentsApi.searchAgentMessages as ReturnType<typeof vi.fn>;
-const mockFetchRecentAgents = agentsApi.fetchRecentAgents as ReturnType<typeof vi.fn>;
+const mockFetchRecentAgentsList = agentsApi.fetchRecentAgentsList as ReturnType<typeof vi.fn>;
+const mockFetchRecentAgentSnippet = agentsApi.fetchRecentAgentSnippet as ReturnType<typeof vi.fn>;
 const scrollIntoViewMock = vi.fn();
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly callback: IntersectionObserverCallback;
+  readonly options: IntersectionObserverInit | undefined;
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  trigger(target: Element, isIntersecting: boolean) {
+    this.callback(
+      [
+        {
+          target,
+          isIntersecting,
+          intersectionRatio: isIntersecting ? 1 : 0,
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRect: isIntersecting ? target.getBoundingClientRect() : new DOMRectReadOnly(),
+          rootBounds: null,
+          time: Date.now(),
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  }
+
+  static reset() {
+    MockIntersectionObserver.instances = [];
+  }
+}
 
 const makeResponse = (results: AgentMessageSearchResponse["results"]): AgentMessageSearchResponse => ({
   results,
@@ -91,6 +131,10 @@ const makeRecentAgent = (overrides?: Partial<RecentAgentForTypeahead>): RecentAg
   session_id: "ses-recent-1",
   parent_id: null,
   tree_id: "tree-recent-1",
+  ...overrides,
+});
+
+const makeRecentSnippet = (overrides?: Partial<RecentAgentSnippet>): RecentAgentSnippet => ({
   lastMessageAt: Date.now() - 30000,
   lastUserMessage: {
     text: "Latest user prompt",
@@ -101,22 +145,26 @@ const makeRecentAgent = (overrides?: Partial<RecentAgentForTypeahead>): RecentAg
 });
 
 const renderDialog = (open = true) => {
-  mockIsOpen = open;
+  mockModalStack = open ? [{ type: "agent-search", id: "main" }] : [];
   render(() => <AgentSearchDialog />);
 };
 
 describe("AgentSearchDialog", () => {
   beforeEach(() => {
+    MockIntersectionObserver.reset();
+    globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
     scrollIntoViewMock.mockReset();
     Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
       value: scrollIntoViewMock,
     });
-    mockFetchRecentAgents.mockResolvedValue([]);
+    mockFetchRecentAgentsList.mockResolvedValue([]);
+    mockFetchRecentAgentSnippet.mockResolvedValue(makeRecentSnippet());
     mockSearchAgentMessages.mockResolvedValue(makeResponse([]));
   });
 
   afterEach(() => {
+    cleanup();
     delete (window.HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView;
     vi.clearAllMocks();
   });
@@ -130,20 +178,20 @@ describe("AgentSearchDialog", () => {
     renderDialog();
 
     await waitFor(() => {
-      expect(mockFetchRecentAgents).toHaveBeenCalledWith("test-workspace", undefined, 50);
+      expect(mockFetchRecentAgentsList).toHaveBeenCalledWith("test-workspace", undefined, 50);
     });
   });
 
   it("renders a Recent section with fetched agents when no query is entered", async () => {
-    mockFetchRecentAgents.mockResolvedValue([makeRecentAgent()]);
+    mockFetchRecentAgentsList.mockResolvedValue([makeRecentAgent()]);
     renderDialog();
 
     expect(await screen.findByText("Recent")).toBeInTheDocument();
     expect(screen.getByText("Recent Agent")).toBeInTheDocument();
   });
 
-  it("renders all agents returned by fetchRecentAgents (limit enforced server-side)", async () => {
-    mockFetchRecentAgents.mockResolvedValue(
+  it("renders all agents returned by fetchRecentAgentsList (limit enforced server-side)", async () => {
+    mockFetchRecentAgentsList.mockResolvedValue(
       Array.from({ length: 50 }, (_, index) =>
         makeRecentAgent({
           id: `agent-recent-${index + 1}`,
@@ -156,6 +204,114 @@ describe("AgentSearchDialog", () => {
     renderDialog();
 
     expect(await screen.findByText("Recent Agent 50")).toBeInTheDocument();
+  });
+
+  it("shows a loading placeholder until a visible recent card snippet resolves", async () => {
+    mockFetchRecentAgentsList.mockResolvedValue([makeRecentAgent()]);
+    let resolveSnippet: ((value: RecentAgentSnippet) => void) | undefined;
+    mockFetchRecentAgentSnippet.mockReturnValue(
+      new Promise<RecentAgentSnippet>((resolve) => {
+        resolveSnippet = resolve;
+      }),
+    );
+
+    renderDialog();
+
+    const recentLink = await screen.findByText("Recent Agent");
+    const card = recentLink.closest("div[class*='rounded-xl']");
+    expect(card).toBeInTheDocument();
+    expect(screen.queryByText("Latest agent response")).not.toBeInTheDocument();
+
+    MockIntersectionObserver.instances[0]?.trigger(card as Element, true);
+
+    await waitFor(() => {
+      expect(mockFetchRecentAgentSnippet).toHaveBeenCalledWith("test-workspace", "agent-recent-1");
+    });
+
+    expect(card?.querySelector("[data-snippet-loading='true']")).toBeInTheDocument();
+
+    resolveSnippet?.(makeRecentSnippet());
+
+    expect(await screen.findByText("Latest agent response")).toBeInTheDocument();
+  });
+
+  it("does not fetch a snippet before a recent card becomes visible", async () => {
+    mockFetchRecentAgentsList.mockResolvedValue([makeRecentAgent()]);
+    renderDialog();
+
+    await screen.findByText("Recent Agent");
+
+    expect(mockFetchRecentAgentSnippet).not.toHaveBeenCalled();
+  });
+
+  it("fetches only the recent card that becomes visible", async () => {
+    mockFetchRecentAgentsList.mockResolvedValue([
+      makeRecentAgent({ id: "agent-recent-1", title: "Visible Recent" }),
+      makeRecentAgent({
+        id: "agent-recent-2",
+        session_id: "ses-recent-2",
+        tree_id: "tree-recent-2",
+        title: "Hidden Recent",
+      }),
+    ]);
+    renderDialog();
+
+    const visibleLink = await screen.findByText("Visible Recent");
+    await screen.findByText("Hidden Recent");
+
+    const visibleCard = visibleLink.closest("div[class*='rounded-xl']");
+    expect(visibleCard).toBeInTheDocument();
+
+    MockIntersectionObserver.instances[0]?.trigger(visibleCard as Element, true);
+
+    await waitFor(() => {
+      expect(mockFetchRecentAgentSnippet).toHaveBeenCalledTimes(1);
+      expect(mockFetchRecentAgentSnippet).toHaveBeenCalledWith("test-workspace", "agent-recent-1");
+    });
+  });
+
+  it("does not fetch snippets while the search dialog is obscured by a higher modal", async () => {
+    mockModalStack = [
+      { type: "agent-search", id: "main" },
+      { type: "agent", id: "agent-123" },
+    ];
+    mockFetchRecentAgentsList.mockResolvedValue([makeRecentAgent()]);
+    render(() => <AgentSearchDialog />);
+
+    const recentLink = await screen.findByText("Recent Agent");
+    const card = recentLink.closest("div[class*='rounded-xl']");
+    expect(card).toBeInTheDocument();
+
+    MockIntersectionObserver.instances[0]?.trigger(card as Element, true);
+
+    await waitFor(() => {
+      expect(mockFetchRecentAgentsList).toHaveBeenCalledWith("test-workspace", undefined, 50);
+    });
+
+    expect(mockFetchRecentAgentSnippet).not.toHaveBeenCalled();
+  });
+
+  it("keeps the preview area blank when snippet loading fails", async () => {
+    mockFetchRecentAgentsList.mockResolvedValue([makeRecentAgent()]);
+    mockFetchRecentAgentSnippet.mockRejectedValue(new Error("snippet failed"));
+    renderDialog();
+
+    const recentLink = await screen.findByText("Recent Agent");
+    const card = recentLink.closest("div[class*='rounded-xl']");
+    expect(card).toBeInTheDocument();
+
+    MockIntersectionObserver.instances[0]?.trigger(card as Element, true);
+
+    await waitFor(() => {
+      expect(mockFetchRecentAgentSnippet).toHaveBeenCalledWith("test-workspace", "agent-recent-1");
+    });
+
+    await waitFor(() => {
+      expect(card?.querySelector("[data-snippet-loading='true']")).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Latest agent response")).not.toBeInTheDocument();
+    expect(card?.querySelector("[data-snippet-empty='true']")).toBeInTheDocument();
   });
 
   it("shows the keyboard hint footer", () => {
@@ -208,7 +364,7 @@ describe("AgentSearchDialog", () => {
     }
 
     async function renderWithRecentAgents() {
-      mockFetchRecentAgents.mockResolvedValue([
+      mockFetchRecentAgentsList.mockResolvedValue([
         makeRecentAgent({ id: "agent-recent-1", title: "Alpha Recent" }),
         makeRecentAgent({
           id: "agent-recent-2",

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -144,6 +144,15 @@ const makeRecentSnippet = (overrides?: Partial<RecentAgentSnippet>): RecentAgent
   ...overrides,
 });
 
+const formatEpochTimestamp = () =>
+  new Date(0).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
 const renderDialog = (open = true) => {
   mockModalStack = open ? [{ type: "agent-search", id: "main" }] : [];
   render(() => <AgentSearchDialog />);
@@ -242,6 +251,15 @@ describe("AgentSearchDialog", () => {
     await screen.findByText("Recent Agent");
 
     expect(mockFetchRecentAgentSnippet).not.toHaveBeenCalled();
+  });
+
+  it("does not render an epoch timestamp before a recent snippet has loaded", async () => {
+    mockFetchRecentAgentsList.mockResolvedValue([makeRecentAgent()]);
+    renderDialog();
+
+    await screen.findByText("Recent Agent");
+
+    expect(screen.queryByText(formatEpochTimestamp())).not.toBeInTheDocument();
   });
 
   it("fetches only the recent card that becomes visible", async () => {

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -158,6 +158,8 @@ const formatEpochTimestamp = () =>
     minute: "2-digit",
   });
 
+// Resets mockModalStack as a side effect. If a test needs a different stack,
+// set mockModalStack after calling renderDialog(), not before.
 const renderDialog = (open = true) => {
   mockModalStack = open ? [{ type: "agent-search", id: "main" }] : [];
   render(() => <AgentSearchDialog />);

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.test.tsx
@@ -4,7 +4,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import type { JSX } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentMessageSearchResponse } from "../services/agents-api";
+import type { AgentMessageSearchResponse, RecentAgentForTypeahead } from "../services/agents-api";
 import * as agentsApi from "../services/agents-api";
 import AgentSearchDialog from "./AgentSearchDialog";
 
@@ -13,6 +13,7 @@ vi.mock("../contexts/WorkspaceContext", () => ({
 }));
 
 vi.mock("../services/agents-api", () => ({
+  fetchRecentAgents: vi.fn(),
   searchAgentMessages: vi.fn(),
 }));
 
@@ -57,6 +58,7 @@ vi.mock("corvu/dialog", () => {
 });
 
 const mockSearchAgentMessages = agentsApi.searchAgentMessages as ReturnType<typeof vi.fn>;
+const mockFetchRecentAgents = agentsApi.fetchRecentAgents as ReturnType<typeof vi.fn>;
 
 const makeResponse = (results: AgentMessageSearchResponse["results"]): AgentMessageSearchResponse => ({
   results,
@@ -82,6 +84,21 @@ const makeResult = (overrides?: Partial<AgentMessageSearchResponse["results"][nu
   ...overrides,
 });
 
+const makeRecentAgent = (overrides?: Partial<RecentAgentForTypeahead>): RecentAgentForTypeahead => ({
+  id: "agent-recent-1",
+  title: "Recent Agent",
+  session_id: "ses-recent-1",
+  parent_id: null,
+  tree_id: "tree-recent-1",
+  lastMessageAt: Date.now() - 30000,
+  lastUserMessage: {
+    text: "Latest user prompt",
+    isAgentSent: false,
+  },
+  lastAgentMessage: "Latest agent response",
+  ...overrides,
+});
+
 const renderDialog = (open = true) => {
   mockIsOpen = open;
   render(() => <AgentSearchDialog />);
@@ -89,6 +106,7 @@ const renderDialog = (open = true) => {
 
 describe("AgentSearchDialog", () => {
   beforeEach(() => {
+    mockFetchRecentAgents.mockResolvedValue([]);
     mockSearchAgentMessages.mockResolvedValue(makeResponse([]));
   });
 
@@ -101,9 +119,45 @@ describe("AgentSearchDialog", () => {
     expect(screen.getByLabelText("Search agent messages")).toBeInTheDocument();
   });
 
-  it("shows idle prompt when no query is entered", () => {
+  it("fetches and shows recent agents immediately on open", async () => {
     renderDialog();
-    expect(screen.getByText("Type to search agent messages")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockFetchRecentAgents).toHaveBeenCalledWith("test-workspace");
+    });
+  });
+
+  it("renders a Recent section with fetched agents when no query is entered", async () => {
+    mockFetchRecentAgents.mockResolvedValue([makeRecentAgent()]);
+    renderDialog();
+
+    expect(await screen.findByText("Recent")).toBeInTheDocument();
+    expect(screen.getByText("Recent Agent")).toBeInTheDocument();
+  });
+
+  it("caps recent agents at 100 items", async () => {
+    mockFetchRecentAgents.mockResolvedValue(
+      Array.from({ length: 101 }, (_, index) =>
+        makeRecentAgent({
+          id: `agent-recent-${index + 1}`,
+          session_id: `ses-recent-${index + 1}`,
+          tree_id: `tree-recent-${index + 1}`,
+          title: `Recent Agent ${index + 1}`,
+        }),
+      ),
+    );
+    renderDialog();
+
+    expect(await screen.findByText("Recent Agent 100")).toBeInTheDocument();
+    expect(screen.queryByText("Recent Agent 101")).not.toBeInTheDocument();
+  });
+
+  it("shows the keyboard hint footer", () => {
+    renderDialog();
+
+    expect(screen.getByText("navigate")).toBeInTheDocument();
+    expect(screen.getByText("peek")).toBeInTheDocument();
+    expect(screen.getByText("open")).toBeInTheDocument();
   });
 
   it("does not render when closed", () => {
@@ -145,6 +199,20 @@ describe("AgentSearchDialog", () => {
       fireEvent.input(input, { target: { value: "agent" } });
       // Wait for debounce + results
       await waitFor(() => expect(screen.getByText("Alpha Agent")).toBeInTheDocument(), { timeout: 1000 });
+    }
+
+    async function renderWithRecentAgents() {
+      mockFetchRecentAgents.mockResolvedValue([
+        makeRecentAgent({ id: "agent-recent-1", title: "Alpha Recent" }),
+        makeRecentAgent({
+          id: "agent-recent-2",
+          session_id: "ses-recent-2",
+          tree_id: "tree-recent-2",
+          title: "Beta Recent",
+        }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Alpha Recent")).toBeInTheDocument(), { timeout: 1000 });
     }
 
     it("ArrowDown moves active index from -1 to 0, highlighting the first result", async () => {
@@ -231,6 +299,35 @@ describe("AgentSearchDialog", () => {
       // No result should be highlighted (aria-current should be absent or false)
       const gammaLink = screen.getByText("Gamma Agent").closest("a");
       expect(gammaLink).not.toHaveAttribute("aria-current", "true");
+    });
+
+    it("ArrowDown highlights the first recent agent when query is empty", async () => {
+      await renderWithRecentAgents();
+      const input = screen.getByLabelText("Search agent messages");
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      await waitFor(() => {
+        const firstLink = screen.getByText("Alpha Recent").closest("a");
+        expect(firstLink).toHaveAttribute("aria-current", "true");
+      });
+    });
+
+    it("Enter with an active recent agent opens it in a modal", async () => {
+      await renderWithRecentAgents();
+      const input = screen.getByLabelText("Search agent messages");
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      await waitFor(() => expect(mockOpenModal).toHaveBeenCalledWith("agent", "agent-recent-1"));
+    });
+
+    it("Cmd+Enter with an active recent agent navigates directly", async () => {
+      await renderWithRecentAgents();
+      const input = screen.getByLabelText("Search agent messages");
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/workspace/test-workspace/agent/agent-recent-1"));
     });
   });
 });

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -614,7 +614,7 @@ const RecentAgentCard: Component<RecentAgentCardProps> = (props) => {
         >
           {props.agent.title || props.agent.id}
         </a>
-        <Show when={snippetData()?.lastMessageAt !== null}>
+        <Show when={snippetData()?.lastMessageAt != null}>
           <span class="text-[11px] text-text-secondary">{formatDateTime(snippetData()?.lastMessageAt ?? 0)}</span>
         </Show>
         <Show

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -535,12 +535,12 @@ const AgentSearchDialog: Component = () => {
               <kbd class="font-mono text-text-muted">↑↓</kbd>
             </span>
             <span class="flex items-center gap-1.5">
-              <span class="font-medium text-text-secondary">peek</span>
-              <kbd class="font-mono text-text-muted">right ⇧</kbd>
-            </span>
-            <span class="flex items-center gap-1.5">
               <span class="font-medium text-text-secondary">open</span>
               <kbd class="font-mono text-text-muted">↵</kbd>
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="font-medium text-text-secondary">peek</span>
+              <kbd class="font-mono text-text-muted">right ⇧</kbd>
             </span>
           </div>
         </Dialog.Content>

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -487,6 +487,7 @@ const AgentSearchDialog: Component = () => {
                         }}
                         agentHref={agentHref(agent.id)}
                         isActive={activeIndex() === index()}
+                        allowHover={pointerMoved()}
                         workspaceId={workspaceId}
                         getObserverRoot={resultsScrollRoot}
                         isSnippetLoadingEnabled={isTopMostSearchDialog}
@@ -520,6 +521,7 @@ const AgentSearchDialog: Component = () => {
                       }}
                       agentHref={agentHref(group.agentId)}
                       isActive={activeIndex() === index()}
+                      allowHover={pointerMoved()}
                     />
                   )}
                 </For>
@@ -551,6 +553,7 @@ interface SearchResultCardProps {
   itemRef: (el: HTMLDivElement) => void;
   agentHref: string | undefined;
   isActive: boolean;
+  allowHover: boolean;
 }
 
 interface RecentAgentCardProps {
@@ -560,6 +563,7 @@ interface RecentAgentCardProps {
   itemRef: (el: HTMLDivElement) => void;
   agentHref: string | undefined;
   isActive: boolean;
+  allowHover: boolean;
   workspaceId: string;
   getObserverRoot: () => HTMLDivElement | undefined;
   isSnippetLoadingEnabled: () => boolean;
@@ -617,7 +621,8 @@ const RecentAgentCard: Component<RecentAgentCardProps> = (props) => {
       class="rounded-xl border border-transparent px-3 py-3 transition-colors"
       classList={{
         "bg-accent/15 text-accent border-accent/30": props.isActive,
-        "text-text-primary hover:bg-surface-overlay": !props.isActive,
+        "text-text-primary": !props.isActive,
+        "hover:bg-surface-overlay": !props.isActive && props.allowHover,
       }}
       onPointerEnter={props.onPointerEnter}
     >
@@ -668,7 +673,7 @@ const SearchResultCard: Component<SearchResultCardProps> = (props) => {
       class="px-4 py-4 space-y-2 transition-colors"
       classList={{
         "bg-accent/15": props.isActive,
-        "hover:bg-surface-overlay": !props.isActive,
+        "hover:bg-surface-overlay": !props.isActive && props.allowHover,
       }}
       onPointerEnter={props.onPointerEnter}
     >

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -5,12 +5,17 @@ import { useNavigate } from "@solidjs/router";
 import Dialog from "corvu/dialog";
 import Popover from "corvu/popover";
 import { Search, X } from "lucide-solid";
-import { type Component, createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { type Component, createEffect, createMemo, createResource, createSignal, For, onCleanup, Show } from "solid-js";
 import { useWorkspace } from "../contexts/WorkspaceContext";
 import { useZIndex } from "../contexts/ZIndexContext";
 import { useModalRoute, useWorkspaceId } from "../lib/routing";
-import type { AgentMessageSearchResult, MessagePart, RecentAgentForTypeahead } from "../services/agents-api";
-import { fetchRecentAgents, searchAgentMessages } from "../services/agents-api";
+import type {
+  AgentMessageSearchResult,
+  MessagePart,
+  RecentAgentForTypeahead,
+  RecentAgentSnippet,
+} from "../services/agents-api";
+import { fetchRecentAgentSnippet, fetchRecentAgentsList, searchAgentMessages } from "../services/agents-api";
 import { cardSurfaceFlat } from "../styles/containerStyles";
 
 export const MODAL_TYPE_AGENT_SEARCH = "agent-search";
@@ -170,8 +175,8 @@ const SectionHeader: Component<{ label: string }> = (props) => (
   </div>
 );
 
-function getRecentAgentPreview(agent: RecentAgentForTypeahead): string {
-  return agent.lastAgentMessage ?? agent.lastUserMessage?.text ?? "No messages yet";
+function getRecentAgentPreview(snippet: RecentAgentSnippet | null | undefined): string {
+  return snippet?.lastAgentMessage ?? snippet?.lastUserMessage?.text ?? "";
 }
 
 const AgentSearchDialog: Component = () => {
@@ -181,6 +186,7 @@ const AgentSearchDialog: Component = () => {
   const { modalStack, removeModalByType, openModal } = useModalRoute();
 
   const isOpen = createMemo(() => modalStack().some((m) => m.type === MODAL_TYPE_AGENT_SEARCH));
+  const isTopMostSearchDialog = createMemo(() => modalStack().at(-1)?.type === MODAL_TYPE_AGENT_SEARCH);
 
   const closeSearch = () => removeModalByType(MODAL_TYPE_AGENT_SEARCH);
 
@@ -198,6 +204,7 @@ const AgentSearchDialog: Component = () => {
 
   let inputRef: HTMLInputElement | undefined;
   let resultItemRefs: Array<HTMLDivElement | undefined> = [];
+  const [resultsScrollRoot, setResultsScrollRoot] = createSignal<HTMLDivElement>();
 
   // Clear state when dialog closes
   createEffect(() => {
@@ -220,7 +227,7 @@ const AgentSearchDialog: Component = () => {
     const thisRequest = ++recentRequestId;
     setIsLoadingRecent(true);
 
-    void fetchRecentAgents(workspaceId, undefined, RECENT_LIMIT)
+    void fetchRecentAgentsList(workspaceId, undefined, RECENT_LIMIT)
       .then((agents) => {
         if (thisRequest !== recentRequestId) return;
         setRecentAgents(agents);
@@ -429,7 +436,7 @@ const AgentSearchDialog: Component = () => {
           </div>
 
           {/* Results area */}
-          <div class="flex-1 overflow-y-auto">
+          <div ref={setResultsScrollRoot} class="flex-1 overflow-y-auto">
             {/* Error state */}
             <Show when={searchError()}>
               <div class="px-4 py-6 text-center">
@@ -461,6 +468,9 @@ const AgentSearchDialog: Component = () => {
                         }}
                         agentHref={agentHref(agent.id)}
                         isActive={activeIndex() === index()}
+                        workspaceId={workspaceId}
+                        getObserverRoot={resultsScrollRoot}
+                        isSnippetLoadingEnabled={isTopMostSearchDialog}
                       />
                     )}
                   </For>
@@ -529,14 +539,60 @@ interface RecentAgentCardProps {
   itemRef: (el: HTMLDivElement) => void;
   agentHref: string | undefined;
   isActive: boolean;
+  workspaceId: string;
+  getObserverRoot: () => HTMLDivElement | undefined;
+  isSnippetLoadingEnabled: () => boolean;
 }
 
 const RecentAgentCard: Component<RecentAgentCardProps> = (props) => {
-  const preview = () => getRecentAgentPreview(props.agent);
+  let itemEl: HTMLDivElement | undefined;
+  const [shouldLoadSnippet, setShouldLoadSnippet] = createSignal(false);
+  const [snippet] = createResource(
+    () => (shouldLoadSnippet() ? props.agent.id : undefined),
+    async (agentId) => fetchRecentAgentSnippet(props.workspaceId, agentId),
+  );
+
+  createEffect(() => {
+    if (shouldLoadSnippet() || !props.isSnippetLoadingEnabled()) return;
+
+    const root = props.getObserverRoot();
+    if (!root || !itemEl) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!props.isSnippetLoadingEnabled()) return;
+
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShouldLoadSnippet(true);
+          observer.disconnect();
+        }
+      },
+      {
+        root,
+        rootMargin: "120px 0px",
+      },
+    );
+
+    observer.observe(itemEl);
+
+    onCleanup(() => observer.disconnect());
+  });
+
+  const snippetData = () => {
+    if (snippet.error) return null;
+    return snippet();
+  };
+
+  const isSnippetLoading = () => shouldLoadSnippet() && snippet.loading && !snippetData();
+  const preview = () => getRecentAgentPreview(snippetData());
+  const hasPreview = () => preview().trim().length > 0;
 
   return (
     <div
-      ref={props.itemRef}
+      ref={(el) => {
+        itemEl = el;
+        props.itemRef(el);
+      }}
       class="rounded-xl border border-transparent px-3 py-3 transition-colors"
       classList={{
         "bg-accent/15 text-accent border-accent/30": props.isActive,
@@ -558,10 +614,23 @@ const RecentAgentCard: Component<RecentAgentCardProps> = (props) => {
         >
           {props.agent.title || props.agent.id}
         </a>
-        <Show when={props.agent.lastMessageAt !== null}>
-          <span class="text-[11px] text-text-secondary">{formatDateTime(props.agent.lastMessageAt ?? 0)}</span>
+        <Show when={snippetData()?.lastMessageAt !== null}>
+          <span class="text-[11px] text-text-secondary">{formatDateTime(snippetData()?.lastMessageAt ?? 0)}</span>
         </Show>
-        <p class="text-sm text-text-secondary leading-relaxed line-clamp-2">{preview()}</p>
+        <Show
+          when={hasPreview()}
+          fallback={
+            <Show when={isSnippetLoading()} fallback={<div class="h-[2.875rem]" data-snippet-empty="true" />}>
+              <div class="space-y-2 pt-0.5" data-snippet-loading="true" aria-hidden="true">
+                <div class="h-3 w-24 rounded-full bg-surface-overlay/80" />
+                <div class="h-3 w-full rounded-full bg-surface-overlay/80" />
+                <div class="h-3 w-2/3 rounded-full bg-surface-overlay/80" />
+              </div>
+            </Show>
+          }
+        >
+          <p class="text-sm text-text-secondary leading-relaxed line-clamp-2">{preview()}</p>
+        </Show>
       </div>
     </div>
   );

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -199,6 +199,9 @@ const AgentSearchDialog: Component = () => {
   const [hasSearched, setHasSearched] = createSignal(false);
   // -1 means no result is keyboard-selected
   const [activeIndex, setActiveIndex] = createSignal(-1);
+  // Tracks whether the pointer has physically moved since the last keyboard navigation.
+  // Prevents pointer-enter from overwriting keyboard selection during arrow key navigation.
+  const [pointerMoved, setPointerMoved] = createSignal(false);
   let requestId = 0;
   let recentRequestId = 0;
 
@@ -356,9 +359,11 @@ const AgentSearchDialog: Component = () => {
 
     if (e.key === "ArrowDown") {
       e.preventDefault();
+      setPointerMoved(false);
       setActiveIndex((i) => (i + 1) % items.length);
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
+      setPointerMoved(false);
       setActiveIndex((i) => (i <= 0 ? items.length - 1 : i - 1));
     } else if (e.key === "Enter") {
       const idx = activeIndex();
@@ -411,6 +416,7 @@ const AgentSearchDialog: Component = () => {
                    flex flex-col overflow-hidden z-[40]`}
           onKeyDown={handleKeyDown}
           onKeyUp={handleKeyUp}
+          onPointerMove={() => setPointerMoved(true)}
         >
           {/* Search input header */}
           <div class="flex items-center gap-2 px-4 py-3 border-b border-border flex-shrink-0">
@@ -473,7 +479,9 @@ const AgentSearchDialog: Component = () => {
                       <RecentAgentCard
                         agent={agent}
                         onAgentClick={(e) => handleAgentClick(agent.id, e)}
-                        onPointerEnter={() => setActiveIndex(index())}
+                        onPointerEnter={() => {
+                          if (pointerMoved()) setActiveIndex(index());
+                        }}
                         itemRef={(el) => {
                           resultItemRefs[index()] = el;
                         }}
@@ -504,7 +512,9 @@ const AgentSearchDialog: Component = () => {
                     <SearchResultCard
                       group={group}
                       onAgentClick={(e) => handleAgentClick(group.agentId, e)}
-                      onPointerEnter={() => setActiveIndex(index())}
+                      onPointerEnter={() => {
+                        if (pointerMoved()) setActiveIndex(index());
+                      }}
                       itemRef={(el) => {
                         resultItemRefs[index()] = el;
                       }}

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -349,7 +349,7 @@ const AgentSearchDialog: Component = () => {
   };
 
   // Keyboard navigation: arrow up/down moves through grouped results;
-  // Enter opens the active result in a modal; Cmd/Ctrl+Enter navigates directly.
+  // Enter opens the active result directly; Right Shift peeks (opens in modal).
   const handleKeyDown = (e: KeyboardEvent) => {
     const items = visibleResults();
     if (items.length === 0) return;
@@ -366,14 +366,24 @@ const AgentSearchDialog: Component = () => {
       const item = items[idx];
       if (!item?.agentId) return;
       e.preventDefault();
-      if (e.metaKey || e.ctrlKey) {
-        // Direct navigation — close search and navigate to the agent's main view
-        closeSearch();
-        navigate(`/workspace/${routeWorkspaceId()}/agent/${item.agentId}`);
-      } else {
-        openModal("agent", item.agentId);
-      }
+      // Enter always opens directly
+      closeSearch();
+      navigate(`/workspace/${routeWorkspaceId()}/agent/${item.agentId}`);
     }
+  };
+
+  // Right Shift peeks the active result in a modal (keyup so held shift doesn't repeat)
+  const handleKeyUp = (e: KeyboardEvent) => {
+    if (e.code !== "ShiftRight") return;
+    // Ignore if any other modifier is held
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const items = visibleResults();
+    const idx = activeIndex();
+    if (idx < 0 || items.length === 0) return;
+    const item = items[idx];
+    if (!item?.agentId) return;
+    e.preventDefault();
+    openModal("agent", item.agentId);
   };
 
   return (
@@ -400,6 +410,7 @@ const AgentSearchDialog: Component = () => {
                    left-1/2 top-[8%] -translate-x-1/2
                    flex flex-col overflow-hidden z-[40]`}
           onKeyDown={handleKeyDown}
+          onKeyUp={handleKeyUp}
         >
           {/* Search input header */}
           <div class="flex items-center gap-2 px-4 py-3 border-b border-border flex-shrink-0">
@@ -511,10 +522,10 @@ const AgentSearchDialog: Component = () => {
               <kbd class="font-mono">↑↓</kbd> navigate
             </span>
             <span>
-              <kbd class="font-mono">↵</kbd> peek
+              <kbd class="font-mono">Right ⇧</kbd> peek
             </span>
             <span>
-              <kbd class="font-mono">⌘↵</kbd> open
+              <kbd class="font-mono">↵</kbd> open
             </span>
           </div>
         </Dialog.Content>

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -9,8 +9,8 @@ import { type Component, createEffect, createMemo, createSignal, For, onCleanup,
 import { useWorkspace } from "../contexts/WorkspaceContext";
 import { useZIndex } from "../contexts/ZIndexContext";
 import { useModalRoute, useWorkspaceId } from "../lib/routing";
-import type { AgentMessageSearchResult, MessagePart } from "../services/agents-api";
-import { searchAgentMessages } from "../services/agents-api";
+import type { AgentMessageSearchResult, MessagePart, RecentAgentForTypeahead } from "../services/agents-api";
+import { fetchRecentAgents, searchAgentMessages } from "../services/agents-api";
 import { cardSurfaceFlat } from "../styles/containerStyles";
 
 export const MODAL_TYPE_AGENT_SEARCH = "agent-search";
@@ -156,8 +156,23 @@ interface GroupedResult {
   matches: AgentMessageSearchResult[];
 }
 
+interface VisibleAgentResult {
+  agentId: string | null;
+}
+
 const SEARCH_LIMIT = 50;
+const RECENT_LIMIT = 100;
 const DEBOUNCE_MS = 300;
+
+const SectionHeader: Component<{ label: string }> = (props) => (
+  <div class="px-4 py-2 text-[11px] font-semibold text-text-muted uppercase tracking-wider select-none">
+    {props.label}
+  </div>
+);
+
+function getRecentAgentPreview(agent: RecentAgentForTypeahead): string {
+  return agent.lastAgentMessage ?? agent.lastUserMessage?.text ?? "No messages yet";
+}
 
 const AgentSearchDialog: Component = () => {
   const { workspaceId } = useWorkspace();
@@ -171,12 +186,15 @@ const AgentSearchDialog: Component = () => {
 
   const [query, setQuery] = createSignal("");
   const [results, setResults] = createSignal<AgentMessageSearchResult[]>([]);
+  const [recentAgents, setRecentAgents] = createSignal<RecentAgentForTypeahead[]>([]);
   const [isSearching, setIsSearching] = createSignal(false);
+  const [isLoadingRecent, setIsLoadingRecent] = createSignal(false);
   const [searchError, setSearchError] = createSignal<string | null>(null);
   const [hasSearched, setHasSearched] = createSignal(false);
   // -1 means no result is keyboard-selected
   const [activeIndex, setActiveIndex] = createSignal(-1);
   let requestId = 0;
+  let recentRequestId = 0;
 
   let inputRef: HTMLInputElement | undefined;
 
@@ -187,14 +205,40 @@ const AgentSearchDialog: Component = () => {
       setQuery("");
       if (inputRef) inputRef.value = "";
       setResults([]);
+      setRecentAgents([]);
       setIsSearching(false);
+      setIsLoadingRecent(false);
       setSearchError(null);
       setHasSearched(false);
     }
   });
 
+  createEffect(() => {
+    if (!isOpen()) return;
+
+    const thisRequest = ++recentRequestId;
+    setIsLoadingRecent(true);
+
+    void fetchRecentAgents(workspaceId)
+      .then((agents) => {
+        if (thisRequest !== recentRequestId) return;
+        setRecentAgents(agents.slice(0, RECENT_LIMIT));
+      })
+      .catch(() => {
+        if (thisRequest !== recentRequestId) return;
+        setRecentAgents([]);
+      })
+      .finally(() => {
+        if (thisRequest === recentRequestId) {
+          setIsLoadingRecent(false);
+        }
+      });
+  });
+
   // Debounced search
   createEffect(() => {
+    if (!isOpen()) return;
+
     const q = query().trim();
 
     if (!q) {
@@ -254,9 +298,17 @@ const AgentSearchDialog: Component = () => {
     return order.map((key) => map.get(key) as GroupedResult);
   });
 
+  const visibleResults = createMemo<VisibleAgentResult[]>(() => {
+    if (!query().trim()) {
+      return recentAgents().map((agent) => ({ agentId: agent.id }));
+    }
+
+    return groupedResults().map((group) => ({ agentId: group.agentId }));
+  });
+
   // Reset keyboard selection whenever results change
   createEffect(() => {
-    groupedResults();
+    visibleResults();
     setActiveIndex(-1);
   });
 
@@ -283,27 +335,27 @@ const AgentSearchDialog: Component = () => {
   // Keyboard navigation: arrow up/down moves through grouped results;
   // Enter opens the active result in a modal; Cmd/Ctrl+Enter navigates directly.
   const handleKeyDown = (e: KeyboardEvent) => {
-    const groups = groupedResults();
-    if (groups.length === 0) return;
+    const items = visibleResults();
+    if (items.length === 0) return;
 
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActiveIndex((i) => (i + 1) % groups.length);
+      setActiveIndex((i) => (i + 1) % items.length);
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setActiveIndex((i) => (i <= 0 ? groups.length - 1 : i - 1));
+      setActiveIndex((i) => (i <= 0 ? items.length - 1 : i - 1));
     } else if (e.key === "Enter") {
       const idx = activeIndex();
       if (idx < 0) return;
-      const group = groups[idx];
-      if (!group?.agentId) return;
+      const item = items[idx];
+      if (!item?.agentId) return;
       e.preventDefault();
       if (e.metaKey || e.ctrlKey) {
         // Direct navigation — close search and navigate to the agent's main view
         closeSearch();
-        navigate(`/workspace/${routeWorkspaceId()}/agent/${group.agentId}`);
+        navigate(`/workspace/${routeWorkspaceId()}/agent/${item.agentId}`);
       } else {
-        openModal("agent", group.agentId);
+        openModal("agent", item.agentId);
       }
     }
   };
@@ -352,7 +404,7 @@ const AgentSearchDialog: Component = () => {
                 aria-label="Search agent messages"
                 data-ph-capture-attribute-element-type="agent-search-dialog-input"
               />
-              <Show when={isSearching()}>
+              <Show when={isSearching() || isLoadingRecent()}>
                 <div class="animate-spin rounded-full h-4 w-4 border-2 border-accent border-t-transparent flex-shrink-0" />
               </Show>
             </div>
@@ -384,10 +436,30 @@ const AgentSearchDialog: Component = () => {
               </div>
             </Show>
 
-            {/* Idle state — nothing typed yet */}
-            <Show when={!query().trim() && !hasSearched()}>
+            {/* Recent agents */}
+            <Show when={!query().trim() && recentAgents().length > 0}>
+              <div class="py-2">
+                <SectionHeader label="Recent" />
+                <div class="px-2 pb-1 space-y-1">
+                  <For each={recentAgents()}>
+                    {(agent, index) => (
+                      <RecentAgentCard
+                        agent={agent}
+                        onAgentClick={(e) => handleAgentClick(agent.id, e)}
+                        onPointerEnter={() => setActiveIndex(index())}
+                        agentHref={agentHref(agent.id)}
+                        isActive={activeIndex() === index()}
+                      />
+                    )}
+                  </For>
+                </div>
+              </div>
+            </Show>
+
+            {/* Empty recent state */}
+            <Show when={!query().trim() && !isLoadingRecent() && recentAgents().length === 0}>
               <div class="px-4 py-10 text-center">
-                <p class="text-sm text-text-muted">Type to search agent messages</p>
+                <p class="text-sm text-text-muted">No recent agents</p>
               </div>
             </Show>
 
@@ -399,6 +471,7 @@ const AgentSearchDialog: Component = () => {
                     <SearchResultCard
                       group={group}
                       onAgentClick={(e) => handleAgentClick(group.agentId, e)}
+                      onPointerEnter={() => setActiveIndex(index())}
                       agentHref={agentHref(group.agentId)}
                       isActive={activeIndex() === index()}
                     />
@@ -406,6 +479,18 @@ const AgentSearchDialog: Component = () => {
                 </For>
               </div>
             </Show>
+          </div>
+
+          <div class="px-4 py-2 border-t border-border flex-shrink-0 flex items-center gap-4 text-xs text-text-muted">
+            <span>
+              <kbd class="font-mono">↑↓</kbd> navigate
+            </span>
+            <span>
+              <kbd class="font-mono">↵</kbd> peek
+            </span>
+            <span>
+              <kbd class="font-mono">⌘↵</kbd> open
+            </span>
           </div>
         </Dialog.Content>
       </Dialog.Portal>
@@ -416,9 +501,53 @@ const AgentSearchDialog: Component = () => {
 interface SearchResultCardProps {
   group: GroupedResult;
   onAgentClick: (e: MouseEvent) => void;
+  onPointerEnter: () => void;
   agentHref: string | undefined;
   isActive: boolean;
 }
+
+interface RecentAgentCardProps {
+  agent: RecentAgentForTypeahead;
+  onAgentClick: (e: MouseEvent) => void;
+  onPointerEnter: () => void;
+  agentHref: string | undefined;
+  isActive: boolean;
+}
+
+const RecentAgentCard: Component<RecentAgentCardProps> = (props) => {
+  const preview = () => getRecentAgentPreview(props.agent);
+
+  return (
+    <div
+      class="rounded-xl border border-transparent px-3 py-3 transition-colors"
+      classList={{
+        "bg-accent/15 text-accent border-accent/30": props.isActive,
+        "text-text-primary hover:bg-surface-overlay": !props.isActive,
+      }}
+      onPointerEnter={props.onPointerEnter}
+    >
+      <div class="flex flex-col gap-1">
+        <a
+          href={props.agentHref}
+          onClick={(e) => props.onAgentClick(e)}
+          class="text-sm font-medium leading-snug"
+          classList={{
+            "text-accent": props.isActive,
+            "text-text-primary hover:text-accent": !props.isActive,
+          }}
+          aria-current={props.isActive ? "true" : undefined}
+          data-agent-id={props.agent.id}
+        >
+          {props.agent.title || props.agent.id}
+        </a>
+        <Show when={props.agent.lastMessageAt !== null}>
+          <span class="text-[11px] text-text-secondary">{formatDateTime(props.agent.lastMessageAt ?? 0)}</span>
+        </Show>
+        <p class="text-sm text-text-secondary leading-relaxed line-clamp-2">{preview()}</p>
+      </div>
+    </div>
+  );
+};
 
 const SearchResultCard: Component<SearchResultCardProps> = (props) => {
   const baseZIndex = useZIndex();
@@ -426,13 +555,24 @@ const SearchResultCard: Component<SearchResultCardProps> = (props) => {
   const matchCount = () => props.group.matches.length;
 
   return (
-    <div class="px-4 py-4 space-y-2" classList={{ "bg-accent/5": props.isActive }}>
+    <div
+      class="px-4 py-4 space-y-2 transition-colors"
+      classList={{
+        "bg-accent/15": props.isActive,
+        "hover:bg-surface-overlay": !props.isActive,
+      }}
+      onPointerEnter={props.onPointerEnter}
+    >
       {/* Agent title + session date range */}
       <div class="flex flex-col gap-0.5">
         <a
           href={props.agentHref}
           onClick={(e) => props.onAgentClick(e)}
-          class="text-sm font-medium text-accent hover:underline leading-snug"
+          class="text-sm font-medium leading-snug"
+          classList={{
+            "text-accent": props.isActive,
+            "text-text-primary hover:text-accent": !props.isActive,
+          }}
           aria-current={props.isActive ? "true" : undefined}
           data-agent-id={props.group.agentId}
         >

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -183,7 +183,7 @@ const AgentSearchDialog: Component = () => {
   const { workspaceId } = useWorkspace();
   const routeWorkspaceId = useWorkspaceId();
   const navigate = useNavigate();
-  const { modalStack, removeModalByType, openModal, closeModal } = useModalRoute();
+  const { modalStack, removeModalByType, openModal } = useModalRoute();
 
   const isOpen = createMemo(() => modalStack().some((m) => m.type === MODAL_TYPE_AGENT_SEARCH));
   const isTopMostSearchDialog = createMemo(() => modalStack().at(-1)?.type === MODAL_TYPE_AGENT_SEARCH);
@@ -373,22 +373,16 @@ const AgentSearchDialog: Component = () => {
   };
 
   // Right Shift peeks the active result in a modal (keyup so held shift doesn't repeat)
-  // If an agent modal is already open on top, Right Shift dismisses it instead
   const handleKeyUp = (e: KeyboardEvent) => {
     if (e.code !== "ShiftRight") return;
     // Ignore if any other modifier is held
     if (e.metaKey || e.ctrlKey || e.altKey) return;
-    e.preventDefault();
-    // Dismiss the peek if one is already open on top
-    if (modalStack().at(-1)?.type === "agent") {
-      closeModal();
-      return;
-    }
     const items = visibleResults();
     const idx = activeIndex();
     if (idx < 0 || items.length === 0) return;
     const item = items[idx];
     if (!item?.agentId) return;
+    e.preventDefault();
     openModal("agent", item.agentId);
   };
 

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -529,15 +529,18 @@ const AgentSearchDialog: Component = () => {
             </Show>
           </div>
 
-          <div class="px-4 py-2 border-t border-border flex-shrink-0 flex items-center gap-3 text-xs text-text-muted">
-            <span class="flex items-center gap-1">
-              navigate <kbd class="font-mono">↑↓</kbd>
+          <div class="px-4 py-2 border-t border-border flex-shrink-0 flex items-center gap-3 text-xs">
+            <span class="flex items-center gap-1.5">
+              <span class="font-medium text-text-secondary">navigate</span>
+              <kbd class="font-mono text-text-muted">↑↓</kbd>
             </span>
-            <span class="flex items-center gap-1">
-              peek <span class="text-text-secondary">right</span> <kbd class="font-mono">⇧</kbd>
+            <span class="flex items-center gap-1.5">
+              <span class="font-medium text-text-secondary">peek</span>
+              <kbd class="font-mono text-text-muted">right ⇧</kbd>
             </span>
-            <span class="flex items-center gap-1">
-              open <kbd class="font-mono">↵</kbd>
+            <span class="flex items-center gap-1.5">
+              <span class="font-medium text-text-secondary">open</span>
+              <kbd class="font-mono text-text-muted">↵</kbd>
             </span>
           </div>
         </Dialog.Content>

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -161,7 +161,7 @@ interface VisibleAgentResult {
 }
 
 const SEARCH_LIMIT = 50;
-const RECENT_LIMIT = 100;
+const RECENT_LIMIT = 50;
 const DEBOUNCE_MS = 300;
 
 const SectionHeader: Component<{ label: string }> = (props) => (
@@ -220,10 +220,10 @@ const AgentSearchDialog: Component = () => {
     const thisRequest = ++recentRequestId;
     setIsLoadingRecent(true);
 
-    void fetchRecentAgents(workspaceId)
+    void fetchRecentAgents(workspaceId, undefined, RECENT_LIMIT)
       .then((agents) => {
         if (thisRequest !== recentRequestId) return;
-        setRecentAgents(agents.slice(0, RECENT_LIMIT));
+        setRecentAgents(agents);
       })
       .catch(() => {
         if (thisRequest !== recentRequestId) return;

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -183,7 +183,7 @@ const AgentSearchDialog: Component = () => {
   const { workspaceId } = useWorkspace();
   const routeWorkspaceId = useWorkspaceId();
   const navigate = useNavigate();
-  const { modalStack, removeModalByType, openModal } = useModalRoute();
+  const { modalStack, removeModalByType, openModal, closeModal } = useModalRoute();
 
   const isOpen = createMemo(() => modalStack().some((m) => m.type === MODAL_TYPE_AGENT_SEARCH));
   const isTopMostSearchDialog = createMemo(() => modalStack().at(-1)?.type === MODAL_TYPE_AGENT_SEARCH);
@@ -373,16 +373,22 @@ const AgentSearchDialog: Component = () => {
   };
 
   // Right Shift peeks the active result in a modal (keyup so held shift doesn't repeat)
+  // If an agent modal is already open on top, Right Shift dismisses it instead
   const handleKeyUp = (e: KeyboardEvent) => {
     if (e.code !== "ShiftRight") return;
     // Ignore if any other modifier is held
     if (e.metaKey || e.ctrlKey || e.altKey) return;
+    e.preventDefault();
+    // Dismiss the peek if one is already open on top
+    if (modalStack().at(-1)?.type === "agent") {
+      closeModal();
+      return;
+    }
     const items = visibleResults();
     const idx = activeIndex();
     if (idx < 0 || items.length === 0) return;
     const item = items[idx];
     if (!item?.agentId) return;
-    e.preventDefault();
     openModal("agent", item.agentId);
   };
 

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -197,6 +197,7 @@ const AgentSearchDialog: Component = () => {
   let recentRequestId = 0;
 
   let inputRef: HTMLInputElement | undefined;
+  let resultItemRefs: Array<HTMLDivElement | undefined> = [];
 
   // Clear state when dialog closes
   createEffect(() => {
@@ -316,7 +317,15 @@ const AgentSearchDialog: Component = () => {
   createEffect(() => {
     if (!isOpen()) {
       setActiveIndex(-1);
+      resultItemRefs = [];
     }
+  });
+
+  createEffect(() => {
+    const idx = activeIndex();
+    if (idx < 0) return;
+
+    resultItemRefs[idx]?.scrollIntoView({ block: "nearest" });
   });
 
   const handleAgentClick = (agentId: string | null, e: MouseEvent) => {
@@ -447,6 +456,9 @@ const AgentSearchDialog: Component = () => {
                         agent={agent}
                         onAgentClick={(e) => handleAgentClick(agent.id, e)}
                         onPointerEnter={() => setActiveIndex(index())}
+                        itemRef={(el) => {
+                          resultItemRefs[index()] = el;
+                        }}
                         agentHref={agentHref(agent.id)}
                         isActive={activeIndex() === index()}
                       />
@@ -472,6 +484,9 @@ const AgentSearchDialog: Component = () => {
                       group={group}
                       onAgentClick={(e) => handleAgentClick(group.agentId, e)}
                       onPointerEnter={() => setActiveIndex(index())}
+                      itemRef={(el) => {
+                        resultItemRefs[index()] = el;
+                      }}
                       agentHref={agentHref(group.agentId)}
                       isActive={activeIndex() === index()}
                     />
@@ -502,6 +517,7 @@ interface SearchResultCardProps {
   group: GroupedResult;
   onAgentClick: (e: MouseEvent) => void;
   onPointerEnter: () => void;
+  itemRef: (el: HTMLDivElement) => void;
   agentHref: string | undefined;
   isActive: boolean;
 }
@@ -510,6 +526,7 @@ interface RecentAgentCardProps {
   agent: RecentAgentForTypeahead;
   onAgentClick: (e: MouseEvent) => void;
   onPointerEnter: () => void;
+  itemRef: (el: HTMLDivElement) => void;
   agentHref: string | undefined;
   isActive: boolean;
 }
@@ -519,6 +536,7 @@ const RecentAgentCard: Component<RecentAgentCardProps> = (props) => {
 
   return (
     <div
+      ref={props.itemRef}
       class="rounded-xl border border-transparent px-3 py-3 transition-colors"
       classList={{
         "bg-accent/15 text-accent border-accent/30": props.isActive,
@@ -556,6 +574,7 @@ const SearchResultCard: Component<SearchResultCardProps> = (props) => {
 
   return (
     <div
+      ref={props.itemRef}
       class="px-4 py-4 space-y-2 transition-colors"
       classList={{
         "bg-accent/15": props.isActive,

--- a/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentSearchDialog.tsx
@@ -529,15 +529,15 @@ const AgentSearchDialog: Component = () => {
             </Show>
           </div>
 
-          <div class="px-4 py-2 border-t border-border flex-shrink-0 flex items-center gap-4 text-xs text-text-muted">
-            <span>
-              <kbd class="font-mono">↑↓</kbd> navigate
+          <div class="px-4 py-2 border-t border-border flex-shrink-0 flex items-center gap-3 text-xs text-text-muted">
+            <span class="flex items-center gap-1">
+              navigate <kbd class="font-mono">↑↓</kbd>
             </span>
-            <span>
-              <kbd class="font-mono">Right ⇧</kbd> peek
+            <span class="flex items-center gap-1">
+              peek <span class="text-text-secondary">right</span> <kbd class="font-mono">⇧</kbd>
             </span>
-            <span>
-              <kbd class="font-mono">↵</kbd> open
+            <span class="flex items-center gap-1">
+              open <kbd class="font-mono">↵</kbd>
             </span>
           </div>
         </Dialog.Content>

--- a/projects/birdhouse/frontend/src/components/WorkspaceLayout.test.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceLayout.test.tsx
@@ -5,10 +5,11 @@ import { render, waitFor } from "@solidjs/testing-library";
 import type { JSX } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openModalMock, setIsCommandPaletteOpenMock, tinykeysMock } = vi.hoisted(() => ({
+const { openModalMock, setIsCommandPaletteOpenMock, tinykeysMock, commandPaletteShortcutMock } = vi.hoisted(() => ({
   openModalMock: vi.fn(),
   setIsCommandPaletteOpenMock: vi.fn(),
   tinykeysMock: vi.fn(),
+  commandPaletteShortcutMock: vi.fn(() => "$mod+k"),
 }));
 
 vi.mock("@solidjs/router", () => ({
@@ -44,7 +45,7 @@ vi.mock("../lib/command-palette-state", () => ({
 }));
 
 vi.mock("../lib/preferences", () => ({
-  commandPaletteShortcut: () => "$mod+k",
+  commandPaletteShortcut: commandPaletteShortcutMock,
 }));
 
 vi.mock("../lib/routing", () => ({
@@ -93,6 +94,31 @@ describe("WorkspaceLayout keyboard shortcuts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     tinykeysMock.mockReturnValue(() => {});
+    commandPaletteShortcutMock.mockReturnValue("$mod+k");
+  });
+
+  it("keeps command palette and agent search bindings independent when shortcuts collide", async () => {
+    commandPaletteShortcutMock.mockReturnValue("$mod+o");
+
+    render(() => <WorkspaceLayout />);
+
+    await waitFor(() => {
+      expect(tinykeysMock).toHaveBeenCalledTimes(2);
+    });
+
+    const handlers = tinykeysMock.mock.calls
+      .map(([, bindings]) => (bindings as Record<string, (event: KeyboardEvent) => void>)["$mod+o"])
+      .filter((handler): handler is (event: KeyboardEvent) => void => typeof handler === "function");
+
+    expect(handlers).toHaveLength(2);
+
+    const preventDefault = vi.fn();
+    handlers[0]?.({ preventDefault } as unknown as KeyboardEvent);
+    handlers[1]?.({ preventDefault } as unknown as KeyboardEvent);
+
+    expect(preventDefault).toHaveBeenCalledTimes(2);
+    expect(setIsCommandPaletteOpenMock).toHaveBeenCalledWith(true);
+    expect(openModalMock).toHaveBeenCalledWith("agent-search", "main");
   });
 
   it("opens agent search when $mod+o is pressed", async () => {
@@ -102,8 +128,9 @@ describe("WorkspaceLayout keyboard shortcuts", () => {
       expect(tinykeysMock).toHaveBeenCalled();
     });
 
-    const bindings = tinykeysMock.mock.calls[0]?.[1] as Record<string, (event: KeyboardEvent) => void>;
-    const handler = bindings?.["$mod+o"];
+    const handler = tinykeysMock.mock.calls
+      .map(([, bindings]) => (bindings as Record<string, (event: KeyboardEvent) => void>)["$mod+o"])
+      .find((candidate): candidate is (event: KeyboardEvent) => void => typeof candidate === "function");
 
     expect(handler).toBeTypeOf("function");
 

--- a/projects/birdhouse/frontend/src/components/WorkspaceLayout.test.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceLayout.test.tsx
@@ -1,0 +1,116 @@
+// ABOUTME: Tests global workspace keyboard shortcuts wired through tinykeys.
+// ABOUTME: Verifies the agent search shortcut opens the dialog from WorkspaceLayout.
+
+import { render, waitFor } from "@solidjs/testing-library";
+import type { JSX } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openModalMock, setIsCommandPaletteOpenMock, tinykeysMock } = vi.hoisted(() => ({
+  openModalMock: vi.fn(),
+  setIsCommandPaletteOpenMock: vi.fn(),
+  tinykeysMock: vi.fn(),
+}));
+
+vi.mock("@solidjs/router", () => ({
+  Navigate: (props: { href: string }) => <div data-testid="navigate">{props.href}</div>,
+  useMatch: () => () => false,
+}));
+
+vi.mock("tinykeys", () => ({
+  tinykeys: tinykeysMock,
+}));
+
+vi.mock("../contexts/SkillCacheContext", () => ({
+  SkillCacheProvider: (props: { children: JSX.Element }) => <>{props.children}</>,
+}));
+
+vi.mock("../contexts/StreamingContext", () => ({
+  StreamingProvider: (props: { children: JSX.Element }) => <>{props.children}</>,
+  useStreaming: () => ({
+    subscribeToWorkspaceRestarting: () => () => {},
+  }),
+}));
+
+vi.mock("../contexts/WorkspaceContext", () => ({
+  WorkspaceProvider: (props: { children: JSX.Element }) => <>{props.children}</>,
+}));
+
+vi.mock("../LiveApp", () => ({
+  default: () => <div>Live App</div>,
+}));
+
+vi.mock("../lib/command-palette-state", () => ({
+  setIsCommandPaletteOpen: setIsCommandPaletteOpenMock,
+}));
+
+vi.mock("../lib/preferences", () => ({
+  commandPaletteShortcut: () => "$mod+k",
+}));
+
+vi.mock("../lib/routing", () => ({
+  useModalRoute: () => ({
+    currentModal: () => null,
+    isModalOpen: () => false,
+    closeModal: vi.fn(),
+    openModal: openModalMock,
+  }),
+  useWorkspaceId: () => () => "ws-test",
+}));
+
+vi.mock("../services/workspaces-api", () => ({
+  fetchWorkspace: vi.fn(async () => ({ title: "Workspace" })),
+  fetchWorkspaceHealth: vi.fn(async () => ({ harnessRunning: true, configError: null })),
+  startWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock("../theme/createMediaQuery", () => ({
+  createMediaQuery: () => () => true,
+}));
+
+vi.mock("../workspace-config/components/WorkspaceConfigDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("./Header", () => ({
+  default: () => <div>Header</div>,
+}));
+
+vi.mock("./WorkspaceBooting", () => ({
+  default: () => <div>Booting</div>,
+}));
+
+vi.mock("./WorkspaceSettings", () => ({
+  default: () => <div>Settings</div>,
+}));
+
+vi.mock("../Playground", () => ({
+  default: () => <div>Playground</div>,
+}));
+
+import WorkspaceLayout from "./WorkspaceLayout";
+
+describe("WorkspaceLayout keyboard shortcuts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tinykeysMock.mockReturnValue(() => {});
+  });
+
+  it("opens agent search when $mod+o is pressed", async () => {
+    render(() => <WorkspaceLayout />);
+
+    await waitFor(() => {
+      expect(tinykeysMock).toHaveBeenCalled();
+    });
+
+    const bindings = tinykeysMock.mock.calls[0]?.[1] as Record<string, (event: KeyboardEvent) => void>;
+    const handler = bindings?.["$mod+o"];
+
+    expect(handler).toBeTypeOf("function");
+
+    const preventDefault = vi.fn();
+    handler?.({ preventDefault } as unknown as KeyboardEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(openModalMock).toHaveBeenCalledWith("agent-search", "main");
+  });
+});

--- a/projects/birdhouse/frontend/src/components/WorkspaceLayout.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceLayout.tsx
@@ -38,7 +38,7 @@ const WorkspaceLayout: Component = () => {
   const workspaceId = useWorkspaceId();
   const isDesktop = createMediaQuery("(min-width: 768px)");
   const [sidebarOpen, setSidebarOpen] = createSignal(isDesktop());
-  const { currentModal, isModalOpen, closeModal } = useModalRoute();
+  const { currentModal, isModalOpen, closeModal, openModal } = useModalRoute();
 
   // Workspace readiness state
   const [isReady, setIsReady] = createSignal(false);
@@ -130,6 +130,10 @@ const WorkspaceLayout: Component = () => {
       [shortcut]: (e: KeyboardEvent) => {
         e.preventDefault();
         setIsCommandPaletteOpen(true);
+      },
+      "$mod+o": (e: KeyboardEvent) => {
+        e.preventDefault();
+        openModal("agent-search", "main");
       },
     });
     onCleanup(unsubscribe);

--- a/projects/birdhouse/frontend/src/components/WorkspaceLayout.tsx
+++ b/projects/birdhouse/frontend/src/components/WorkspaceLayout.tsx
@@ -126,17 +126,22 @@ const WorkspaceLayout: Component = () => {
   // Re-registers whenever the user changes the configured shortcut.
   createEffect(() => {
     const shortcut = commandPaletteShortcut();
-    const unsubscribe = tinykeys(window, {
+    const unsubscribeCommandPalette = tinykeys(window, {
       [shortcut]: (e: KeyboardEvent) => {
         e.preventDefault();
         setIsCommandPaletteOpen(true);
       },
+    });
+    const unsubscribeAgentSearch = tinykeys(window, {
       "$mod+o": (e: KeyboardEvent) => {
         e.preventDefault();
         openModal("agent-search", "main");
       },
     });
-    onCleanup(unsubscribe);
+    onCleanup(() => {
+      unsubscribeCommandPalette();
+      unsubscribeAgentSearch();
+    });
   });
 
   // Called by WorkspaceRestartWatcher when a restart event arrives

--- a/projects/birdhouse/frontend/src/components/ui/AgentTypeahead.test.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AgentTypeahead.test.tsx
@@ -1,0 +1,62 @@
+// ABOUTME: Tests @@ typeahead lazy snippet loading for recent agents.
+// ABOUTME: Verifies slim recent-agent rows fetch and render per-agent previews.
+
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { AgentTypeahead } from "./AgentTypeahead";
+
+const fetchRecentAgentSnippetMock = vi.fn();
+
+vi.mock("../../contexts/ZIndexContext", () => ({
+  useZIndex: () => 100,
+}));
+
+vi.mock("../../services/agents-api", () => ({
+  fetchRecentAgentSnippet: (workspaceId: string, agentId: string) => fetchRecentAgentSnippetMock(workspaceId, agentId),
+}));
+
+describe("AgentTypeahead", () => {
+  it("fetches and renders snippet previews for slim recent-agent rows", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_060_000);
+    fetchRecentAgentSnippetMock.mockResolvedValue({
+      lastMessageAt: 1_700_000_000_000,
+      lastUserMessage: {
+        text: "User follow-up",
+        isAgentSent: false,
+      },
+      lastAgentMessage: "Agent summary",
+    });
+
+    render(() => (
+      <AgentTypeahead
+        referenceElement={undefined}
+        inputValue="@@"
+        cursorPosition={2}
+        visible={true}
+        workspaceId="ws_test"
+        agents={[
+          {
+            id: "agent_1",
+            title: "Recent Agent",
+            session_id: "session_1",
+            parent_id: null,
+            tree_id: "tree_1",
+          },
+        ]}
+        currentAgentId={undefined}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />
+    ));
+
+    await waitFor(() => {
+      expect(fetchRecentAgentSnippetMock).toHaveBeenCalledWith("ws_test", "agent_1");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent summary")).toBeInTheDocument();
+      expect(screen.getByText("User follow-up")).toBeInTheDocument();
+      expect(screen.getByText("1m ago")).toBeInTheDocument();
+    });
+  });
+});

--- a/projects/birdhouse/frontend/src/components/ui/AgentTypeahead.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AgentTypeahead.tsx
@@ -3,8 +3,9 @@
 
 import { autoUpdate, flip, offset, shift, size } from "@floating-ui/dom";
 import { useFloating } from "solid-floating-ui";
-import { type Component, createEffect, createSignal, For, onCleanup, Show } from "solid-js";
+import { type Component, createEffect, createResource, createSignal, For, onCleanup, Show } from "solid-js";
 import { useZIndex } from "../../contexts/ZIndexContext";
+import { fetchRecentAgentSnippet } from "../../services/agents-api";
 import { uiSize } from "../../theme";
 
 export interface Agent {
@@ -31,6 +32,8 @@ export interface AgentTypeaheadProps {
   cursorPosition: number;
   /** Whether the dropdown should be visible */
   visible: boolean;
+  /** Workspace ID used to load recent agent snippets */
+  workspaceId: string;
   /** Array of agents to match against */
   agents: Agent[];
   /** ID of the current agent to filter out */
@@ -105,6 +108,150 @@ const MessageBubble: Component<MessageBubbleProps> = (props) => {
       </div>
     </div>
   );
+};
+
+interface AgentOptionProps {
+  agent: Agent;
+  highlighted: boolean;
+  sizeClasses: { option: string; meta: string; message: string };
+  workspaceId: string;
+  onSelect: () => void;
+  onMouseEnter: () => void;
+}
+
+const AgentOption: Component<AgentOptionProps> = (props) => {
+  const [snippet] = createResource(
+    () => props.agent.id,
+    (agentId) => fetchRecentAgentSnippet(props.workspaceId, agentId),
+  );
+
+  const snippetData = () => {
+    if (snippet.error) return null;
+    return snippet();
+  };
+
+  const lastMessageAt = () => snippetData()?.lastMessageAt ?? props.agent.lastMessageAt;
+  const lastAgentMessage = () => snippetData()?.lastAgentMessage ?? props.agent.lastAgentMessage;
+  const lastUserMessage = () => snippetData()?.lastUserMessage ?? props.agent.lastUserMessage;
+  const isSnippetLoading = () => snippet.loading && !snippetData();
+
+  return (
+    <div
+      role="option"
+      tabIndex={-1}
+      aria-selected={props.highlighted}
+      class="px-3 py-2 cursor-pointer transition-colors"
+      classList={{
+        [props.sizeClasses.option]: true,
+        "bg-gradient-from/30 text-text-primary": props.highlighted,
+        "hover:bg-surface-raised": !props.highlighted,
+      }}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onClick={props.onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          props.onSelect();
+        }
+      }}
+      onMouseEnter={props.onMouseEnter}
+    >
+      <div class="flex flex-col gap-1 py-1">
+        <div class="flex items-baseline justify-between gap-2">
+          <div class="font-medium text-text-primary truncate flex-1">{props.agent.title}</div>
+          <div class={`${props.sizeClasses.meta} text-text-secondary shrink-0`}>{formatTimestamp(lastMessageAt())}</div>
+        </div>
+
+        <div class="flex flex-col gap-1.5 mt-1">
+          <Show
+            when={lastAgentMessage()}
+            fallback={
+              <Show when={isSnippetLoading()} fallback={null}>
+                <div class="space-y-2 pt-0.5" data-snippet-loading="true" aria-hidden="true">
+                  <div class="h-3 w-24 rounded-full bg-surface-overlay/80" />
+                  <div class="h-3 w-full rounded-full bg-surface-overlay/80" />
+                  <div class="h-3 w-2/3 rounded-full bg-surface-overlay/80" />
+                </div>
+              </Show>
+            }
+          >
+            {(message) => (
+              <MessageBubble
+                message={message()}
+                justify="start"
+                background="var(--theme-surface-raised)"
+                boxShadow="0 0 0 1px color-mix(in srgb, var(--theme-border) 50%, transparent)"
+                maxWidth="max-w-[85%]"
+                sizeClasses={props.sizeClasses}
+              />
+            )}
+          </Show>
+          <Show when={lastUserMessage()}>
+            {(message) => (
+              <>
+                <Show
+                  when={message().isAgentSent}
+                  fallback={
+                    <MessageBubble
+                      message={message().text}
+                      justify="end"
+                      background="color-mix(in srgb, var(--theme-accent) 15%, var(--theme-surface-raised))"
+                      boxShadow={`0 0 0 1px color-mix(in srgb, var(--theme-accent) 30%, transparent),
+                            0 2px 8px -2px color-mix(in srgb, var(--theme-accent) 20%, transparent)`}
+                      maxWidth="max-w-[85%]"
+                      gradientBackground={`linear-gradient(to bottom,
+                            transparent,
+                            color-mix(in srgb, var(--theme-accent) 15%, var(--theme-surface-raised))
+                          )`}
+                      sizeClasses={props.sizeClasses}
+                    />
+                  }
+                >
+                  <MessageBubble
+                    message={message().text}
+                    justify="center"
+                    background={`linear-gradient(to right,
+                            color-mix(in srgb, var(--theme-gradient-from) 20%, var(--theme-surface-raised)),
+                            color-mix(in srgb, var(--theme-gradient-via) 20%, var(--theme-surface-raised)),
+                            color-mix(in srgb, var(--theme-gradient-to) 20%, var(--theme-surface-raised))
+                          )`}
+                    boxShadow={`0 0 0 1px color-mix(in srgb, var(--theme-gradient-via) 40%, transparent),
+                            0 2px 8px -2px color-mix(in srgb, var(--theme-gradient-via) 25%, transparent)`}
+                    maxWidth="max-w-[90%]"
+                    gradientBackground={`linear-gradient(to bottom,
+                            transparent,
+                            color-mix(in srgb, var(--theme-gradient-via) 20%, var(--theme-surface-raised))
+                          )`}
+                    sizeClasses={props.sizeClasses}
+                  />
+                </Show>
+              </>
+            )}
+          </Show>
+          <Show when={!isSnippetLoading() && !lastAgentMessage() && !lastUserMessage()}>
+            <div class="h-[2.875rem]" data-snippet-empty="true" />
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const formatTimestamp = (timestamp: number | null | undefined): string => {
+  if (!timestamp) return "No messages";
+  const now = Date.now();
+  const diff = now - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  return `${days}d ago`;
 };
 
 export const AgentTypeahead: Component<AgentTypeaheadProps> = (props) => {
@@ -294,21 +441,6 @@ export const AgentTypeahead: Component<AgentTypeaheadProps> = (props) => {
     };
   };
 
-  // Format timestamp for display
-  const formatTimestamp = (timestamp: number | null | undefined): string => {
-    if (!timestamp) return "No messages";
-    const now = Date.now();
-    const diff = now - timestamp;
-    const minutes = Math.floor(diff / 60000);
-    const hours = Math.floor(diff / 3600000);
-    const days = Math.floor(diff / 86400000);
-
-    if (minutes < 1) return "Just now";
-    if (minutes < 60) return `${minutes}m ago`;
-    if (hours < 24) return `${hours}h ago`;
-    return `${days}d ago`;
-  };
-
   const shouldShow = () => {
     const displayed = displayAgents();
     return props.visible && displayed.length > 0;
@@ -334,102 +466,21 @@ export const AgentTypeahead: Component<AgentTypeaheadProps> = (props) => {
       >
         <For each={displayAgents()}>
           {(agent, index) => (
-            <div
-              role="option"
-              tabIndex={-1}
-              aria-selected={highlightedIndex() === index()}
-              class="px-3 py-2 cursor-pointer transition-colors"
-              classList={{
-                [sizeClasses().option]: true,
-                "bg-gradient-from/30 text-text-primary": highlightedIndex() === index(),
-                "hover:bg-surface-raised": highlightedIndex() !== index(),
-              }}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-              onClick={() => {
+            <AgentOption
+              agent={agent}
+              highlighted={highlightedIndex() === index()}
+              sizeClasses={sizeClasses()}
+              workspaceId={props.workspaceId}
+              onSelect={() => {
                 const match = getBestMatch(agent);
                 if (match) {
                   props.onSelect(agent, match.matchedText, match.startIndex);
                 }
               }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  const match = getBestMatch(agent);
-                  if (match) {
-                    props.onSelect(agent, match.matchedText, match.startIndex);
-                  }
-                }
-              }}
               onMouseEnter={() => {
                 setHighlightedIndex(index());
               }}
-            >
-              <div class="flex flex-col gap-1 py-1">
-                <div class="flex items-baseline justify-between gap-2">
-                  <div class="font-medium text-text-primary truncate flex-1">{agent.title}</div>
-                  <div class={`${sizeClasses().meta} text-text-secondary shrink-0`}>
-                    {formatTimestamp(agent.lastMessageAt)}
-                  </div>
-                </div>
-
-                <div class="flex flex-col gap-1.5 mt-1">
-                  {/* Agent message first (older, higher up) - mini bubble left */}
-                  {agent.lastAgentMessage && (
-                    <MessageBubble
-                      message={agent.lastAgentMessage}
-                      justify="start"
-                      background="var(--theme-surface-raised)"
-                      boxShadow="0 0 0 1px color-mix(in srgb, var(--theme-border) 50%, transparent)"
-                      maxWidth="max-w-[85%]"
-                      sizeClasses={sizeClasses()}
-                    />
-                  )}
-                  {/* User message second (newer, lower down) */}
-                  {agent.lastUserMessage && (
-                    <>
-                      {/* Agent-sent: centered with gradient (like main chat) */}
-                      {agent.lastUserMessage.isAgentSent ? (
-                        <MessageBubble
-                          message={agent.lastUserMessage.text}
-                          justify="center"
-                          background={`linear-gradient(to right,
-                            color-mix(in srgb, var(--theme-gradient-from) 20%, var(--theme-surface-raised)),
-                            color-mix(in srgb, var(--theme-gradient-via) 20%, var(--theme-surface-raised)),
-                            color-mix(in srgb, var(--theme-gradient-to) 20%, var(--theme-surface-raised))
-                          )`}
-                          boxShadow={`0 0 0 1px color-mix(in srgb, var(--theme-gradient-via) 40%, transparent),
-                            0 2px 8px -2px color-mix(in srgb, var(--theme-gradient-via) 25%, transparent)`}
-                          maxWidth="max-w-[90%]"
-                          gradientBackground={`linear-gradient(to bottom,
-                            transparent,
-                            color-mix(in srgb, var(--theme-gradient-via) 20%, var(--theme-surface-raised))
-                          )`}
-                          sizeClasses={sizeClasses()}
-                        />
-                      ) : (
-                        /* Human user message: right-aligned with accent tint */
-                        <MessageBubble
-                          message={agent.lastUserMessage.text}
-                          justify="end"
-                          background="color-mix(in srgb, var(--theme-accent) 15%, var(--theme-surface-raised))"
-                          boxShadow={`0 0 0 1px color-mix(in srgb, var(--theme-accent) 30%, transparent),
-                            0 2px 8px -2px color-mix(in srgb, var(--theme-accent) 20%, transparent)`}
-                          maxWidth="max-w-[85%]"
-                          gradientBackground={`linear-gradient(to bottom,
-                            transparent,
-                            color-mix(in srgb, var(--theme-accent) 15%, var(--theme-surface-raised))
-                          )`}
-                          sizeClasses={sizeClasses()}
-                        />
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
+            />
           )}
         </For>
       </div>

--- a/projects/birdhouse/frontend/src/components/ui/AgentTypeahead.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AgentTypeahead.tsx
@@ -13,13 +13,13 @@ export interface Agent {
   session_id: string;
   parent_id: string | null;
   tree_id: string;
-  lastMessageAt: number | null;
-  lastUserMessage: {
+  lastMessageAt?: number | null;
+  lastUserMessage?: {
     text: string;
     isAgentSent: boolean;
     sentByAgentTitle?: string;
   } | null;
-  lastAgentMessage: string | null;
+  lastAgentMessage?: string | null;
 }
 
 export interface AgentTypeaheadProps {
@@ -295,7 +295,7 @@ export const AgentTypeahead: Component<AgentTypeaheadProps> = (props) => {
   };
 
   // Format timestamp for display
-  const formatTimestamp = (timestamp: number | null): string => {
+  const formatTimestamp = (timestamp: number | null | undefined): string => {
     if (!timestamp) return "No messages";
     const now = Date.now();
     const diff = now - timestamp;

--- a/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.skill-refresh.test.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.skill-refresh.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../../lib/routing", () => ({
 }));
 
 vi.mock("../../services/agents-api", () => ({
-  fetchRecentAgents: async () => [],
+  fetchRecentAgentsList: async () => [],
 }));
 
 vi.mock("../../skills/services/skill-library-api", () => ({

--- a/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.test.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.test.tsx
@@ -38,7 +38,7 @@ vi.mock("../../lib/routing", () => ({
 }));
 
 vi.mock("../../services/agents-api", () => ({
-  fetchRecentAgents: async () => [],
+  fetchRecentAgentsList: async () => [],
 }));
 
 vi.mock("../../services/messages-api", () => ({

--- a/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.tsx
@@ -368,6 +368,7 @@ export const AutoGrowTextarea: Component<AutoGrowTextareaProps> = (props) => {
         inputValue={props.value}
         cursorPosition={cursorPosition()}
         visible={showAgentTypeahead()}
+        workspaceId={workspaceId}
         agents={typeaheadAgents()}
         currentAgentId={currentAgentId()}
         onSelect={handleAgentSelect}

--- a/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/AutoGrowTextarea.tsx
@@ -5,7 +5,7 @@ import { type Component, createEffect, createMemo, createResource, createSignal 
 import { useSkillCache } from "../../contexts/SkillCacheContext";
 import { useWorkspace } from "../../contexts/WorkspaceContext";
 import { useWorkspaceAgentId } from "../../lib/routing";
-import { fetchRecentAgents } from "../../services/agents-api";
+import { fetchRecentAgentsList } from "../../services/agents-api";
 import { fetchModels } from "../../services/messages-api";
 import { uiSize } from "../../theme";
 import { buildModelMarkdownLink } from "../../utils/modelLinks";
@@ -40,8 +40,8 @@ export const AutoGrowTextarea: Component<AutoGrowTextareaProps> = (props) => {
   // Get skills from cache (always up-to-date via SSE)
   const { skills: skillsData } = useSkillCache();
 
-  // Load recent agents once on mount (server-side, with message context)
-  const [agentsData] = createResource(() => fetchRecentAgents(workspaceId));
+  // Load recent agents once on mount for the agent typeahead list
+  const [agentsData] = createResource(() => fetchRecentAgentsList(workspaceId));
 
   // Load models once on mount
   const [modelsData] = createResource(() => fetchModels(workspaceId));

--- a/projects/birdhouse/frontend/src/components/ui/ChatContainer.test.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/ChatContainer.test.tsx
@@ -38,7 +38,7 @@ vi.mock("../../services/skill-attachments-api", () => ({
 }));
 
 vi.mock("../../services/agents-api", () => ({
-  fetchRecentAgents: vi.fn(async () => []),
+  fetchRecentAgentsList: vi.fn(async () => []),
 }));
 
 describe("ChatContainer", () => {

--- a/projects/birdhouse/frontend/src/services/agents-api.ts
+++ b/projects/birdhouse/frontend/src/services/agents-api.ts
@@ -51,7 +51,7 @@ export interface AgentForTypeahead {
 }
 
 /**
- * Recent agent with message context for typeahead
+ * Recent agent row for typeahead
  */
 export interface RecentAgentForTypeahead {
   id: string;
@@ -59,6 +59,12 @@ export interface RecentAgentForTypeahead {
   session_id: string;
   parent_id: string | null;
   tree_id: string;
+}
+
+/**
+ * Recent agent snippet loaded on demand
+ */
+export interface RecentAgentSnippet {
   lastMessageAt: number | null;
   lastUserMessage: {
     text: string;
@@ -74,6 +80,19 @@ export interface RecentAgentForTypeahead {
 export interface RecentAgentsResponse {
   agents: RecentAgentForTypeahead[];
   total: number;
+}
+
+/**
+ * Response from recent agent snippet endpoint
+ */
+export interface RecentAgentSnippetResponse {
+  lastMessageAt: number | null;
+  lastUserMessage: {
+    text: string;
+    isAgentSent: boolean;
+    sentByAgentTitle?: string;
+  } | null;
+  lastAgentMessage: string | null;
 }
 
 /**
@@ -259,13 +278,13 @@ export async function fetchAgentsForTypeahead(workspaceId: string): Promise<Agen
 }
 
 /**
- * Fetch recent agents with message context for typeahead
+ * Fetch recent agents for typeahead
  * @param workspaceId The workspace ID
  * @param query Optional search query to filter agents
- * @param limit Optional maximum number of agents to return (applied server-side before message fetches)
- * @returns Array of recent agents with last message context
+ * @param limit Optional maximum number of agents to return
+ * @returns Array of recent agents
  */
-export async function fetchRecentAgents(
+export async function fetchRecentAgentsList(
   workspaceId: string,
   query?: string,
   limit?: number,
@@ -301,4 +320,34 @@ export async function fetchRecentAgents(
 
   const data = (await response.json()) as RecentAgentsResponse;
   return data.agents;
+}
+
+/**
+ * Fetch the latest message snippet for one recent agent
+ * @param workspaceId The workspace ID
+ * @param agentId The agent ID
+ * @returns The latest snippet metadata for the agent
+ */
+export async function fetchRecentAgentSnippet(workspaceId: string, agentId: string): Promise<RecentAgentSnippet> {
+  const url = buildWorkspaceUrl(workspaceId, `/agents/${agentId}/messages/snippet`);
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    let errorMessage = `Failed to fetch recent agent snippet: ${response.statusText}`;
+
+    try {
+      const errorData = JSON.parse(responseBody);
+      if (errorData.error) {
+        errorMessage = errorData.error;
+      }
+    } catch {
+      // Response wasn't JSON, use status text
+    }
+
+    throw new Error(errorMessage);
+  }
+
+  return (await response.json()) as RecentAgentSnippetResponse;
 }

--- a/projects/birdhouse/frontend/src/services/agents-api.ts
+++ b/projects/birdhouse/frontend/src/services/agents-api.ts
@@ -262,12 +262,20 @@ export async function fetchAgentsForTypeahead(workspaceId: string): Promise<Agen
  * Fetch recent agents with message context for typeahead
  * @param workspaceId The workspace ID
  * @param query Optional search query to filter agents
+ * @param limit Optional maximum number of agents to return (applied server-side before message fetches)
  * @returns Array of recent agents with last message context
  */
-export async function fetchRecentAgents(workspaceId: string, query?: string): Promise<RecentAgentForTypeahead[]> {
+export async function fetchRecentAgents(
+  workspaceId: string,
+  query?: string,
+  limit?: number,
+): Promise<RecentAgentForTypeahead[]> {
   const params = new URLSearchParams();
   if (query?.trim()) {
     params.set("q", query.trim());
+  }
+  if (limit !== undefined) {
+    params.set("limit", String(limit));
   }
 
   const url = `${buildWorkspaceUrl(workspaceId, "/agents/recent")}?${params}`;

--- a/projects/birdhouse/server/src/features/api/get-agent-snippet.test.ts
+++ b/projects/birdhouse/server/src/features/api/get-agent-snippet.test.ts
@@ -1,0 +1,139 @@
+// ABOUTME: Tests for GET /api/agents/:id/messages/snippet
+// ABOUTME: Verifies response shape, 404 on unknown agent, and graceful empty-message handling
+
+import { describe, expect, test } from "bun:test";
+import { createTestDeps } from "../../dependencies";
+import type { BirdhouseMessage as Message } from "../../harness";
+import { initAgentsDB } from "../../lib/agents-db";
+import { createTestApp } from "../../test-utils";
+import { createRootAgent } from "../../test-utils/agent-factories";
+import { getAgentSnippet } from "./get-agent-snippet";
+
+const SESSION_ID = "ses_snippet_test";
+const AGENT_ID = "agent_snippet_test";
+
+interface SnippetResponse {
+  lastMessageAt: number | null;
+  lastUserMessage: {
+    text: string;
+    isAgentSent: boolean;
+    sentByAgentTitle?: string;
+  } | null;
+  lastAgentMessage: string | null;
+}
+
+function makeUserMessage(id: string, created: number, text: string, metadata?: Record<string, unknown>): Message {
+  return {
+    info: { id, sessionID: SESSION_ID, role: "user", time: { created } },
+    parts: [
+      {
+        id: `${id}_part`,
+        sessionID: SESSION_ID,
+        messageID: id,
+        type: "text",
+        text,
+        ...(metadata ? { metadata } : {}),
+      },
+    ],
+  };
+}
+
+function makeAssistantMessage(id: string, created: number, text: string): Message {
+  return {
+    info: {
+      id,
+      sessionID: SESSION_ID,
+      role: "assistant",
+      time: { created },
+      parentID: `${id}_parent`,
+      modelID: "claude-sonnet-4",
+      providerID: "anthropic",
+    },
+    parts: [{ id: `${id}_part`, sessionID: SESSION_ID, messageID: id, type: "text", text }],
+  };
+}
+
+async function buildApp(messages: Message[] = []) {
+  const agentsDB = await initAgentsDB(":memory:");
+
+  createRootAgent(agentsDB, {
+    id: AGENT_ID,
+    session_id: SESSION_ID,
+    title: "Snippet Test Agent",
+  });
+
+  const deps = await createTestDeps();
+  deps.agentsDB = agentsDB;
+  deps.harness.getMessages = async () => messages;
+
+  const app = await createTestApp({ agentsDb: agentsDB });
+  app.get("/:id/messages/snippet", (c) => getAgentSnippet(c, deps));
+
+  return { app };
+}
+
+describe("getAgentSnippet - GET /:id/messages/snippet", () => {
+  test("returns 404 for unknown agent", async () => {
+    const { app } = await buildApp();
+
+    const res = await app.request("/agent_unknown/messages/snippet");
+    expect(res.status).toBe(404);
+  });
+
+  test("returns null fields when agent has no messages", async () => {
+    const { app } = await buildApp([]);
+
+    const res = await app.request(`/${AGENT_ID}/messages/snippet`);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as SnippetResponse;
+    expect(body.lastMessageAt).toBeNull();
+    expect(body.lastUserMessage).toBeNull();
+    expect(body.lastAgentMessage).toBeNull();
+  });
+
+  test("returns lastAgentMessage from last assistant message", async () => {
+    const messages = [
+      makeUserMessage("msg_user", 1000, "hello"),
+      makeAssistantMessage("msg_asst", 2000, "Hi there, how can I help?"),
+    ];
+
+    const { app } = await buildApp(messages);
+    const res = await app.request(`/${AGENT_ID}/messages/snippet`);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as SnippetResponse;
+    expect(body.lastMessageAt).toBe(2000);
+    expect(body.lastAgentMessage).toBe("Hi there, how can I help?");
+    expect(body.lastUserMessage?.text).toBe("hello");
+    expect(body.lastUserMessage?.isAgentSent).toBe(false);
+  });
+
+  test("truncates long messages to 200 characters", async () => {
+    const longText = "a".repeat(300);
+    const messages = [makeAssistantMessage("msg_long", 1000, longText)];
+
+    const { app } = await buildApp(messages);
+    const res = await app.request(`/${AGENT_ID}/messages/snippet`);
+    const body = (await res.json()) as SnippetResponse;
+
+    expect(body.lastAgentMessage?.length).toBeLessThanOrEqual(203); // 200 + "..."
+    expect(body.lastAgentMessage).toMatch(/\.\.\.$/);
+  });
+
+  test("detects agent-sent user messages via metadata", async () => {
+    const messages = [
+      makeUserMessage("msg_agent_sent", 1000, "reply from agent", {
+        sent_by_agent_id: "agent_other",
+        sent_by_agent_title: "Other Agent",
+      }),
+    ];
+
+    const { app } = await buildApp(messages);
+    const res = await app.request(`/${AGENT_ID}/messages/snippet`);
+    const body = (await res.json()) as SnippetResponse;
+
+    expect(body.lastUserMessage?.isAgentSent).toBe(true);
+    expect(body.lastUserMessage?.sentByAgentTitle).toBe("Other Agent");
+  });
+});

--- a/projects/birdhouse/server/src/features/api/get-agent-snippet.ts
+++ b/projects/birdhouse/server/src/features/api/get-agent-snippet.ts
@@ -1,0 +1,103 @@
+// ABOUTME: Get last message snippet for a single agent — used by the typeahead recent list
+// ABOUTME: Returns lastMessageAt, lastUserMessage, and lastAgentMessage for one agent by ID
+
+import type { Context } from "hono";
+import { type Deps, getHarnessForAgent } from "../../dependencies";
+import type { BirdhouseMessage as Message } from "../../harness";
+
+const MAX_SNIPPET_LENGTH = 200;
+
+interface AgentSnippetResponse {
+  lastMessageAt: number | null;
+  lastUserMessage: {
+    text: string;
+    isAgentSent: boolean;
+    sentByAgentTitle?: string;
+  } | null;
+  lastAgentMessage: string | null;
+}
+
+/**
+ * Extract text content from message parts, truncated to maxLength
+ */
+function extractMessageText(message: Message, maxLength: number): string {
+  const textParts = message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => (part as { type: "text"; text: string }).text);
+
+  const fullText = textParts.join(" ").trim();
+
+  if (fullText.length <= maxLength) {
+    return fullText;
+  }
+
+  return `${fullText.slice(0, maxLength - 3)}...`;
+}
+
+/**
+ * GET /api/agents/:id/messages/snippet
+ * Returns the last user and assistant message snippets for a single agent.
+ * Used by the typeahead dialog to lazily load per-card previews.
+ */
+export async function getAgentSnippet(c: Context, deps: Pick<Deps, "agentsDB" | "harnesses">) {
+  const { agentsDB } = deps;
+  const agentId = c.req.param("id");
+
+  try {
+    const agent = agentsDB.getAgentById(agentId);
+    if (!agent) {
+      return c.json({ error: `Agent ${agentId} not found` }, 404);
+    }
+
+    const harness = getHarnessForAgent(deps, agent);
+    const messages = await harness.getMessages(agent.session_id, 100);
+
+    if (messages.length === 0) {
+      return c.json<AgentSnippetResponse>({
+        lastMessageAt: null,
+        lastUserMessage: null,
+        lastAgentMessage: null,
+      });
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    const lastMessageAt = lastMessage.info.time.created;
+
+    // Find last user message (search from end)
+    let lastUserMessage: AgentSnippetResponse["lastUserMessage"] = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.info.role === "user") {
+        const text = extractMessageText(msg, MAX_SNIPPET_LENGTH);
+        const firstTextPart = msg.parts.find((p) => p.type === "text") as
+          | { type: "text"; text: string; metadata?: Record<string, unknown> }
+          | undefined;
+        const metadata = firstTextPart?.metadata;
+        const isAgentSent = !!(metadata?.sent_by_agent_id || metadata?.sent_by_agent_title);
+        lastUserMessage = {
+          text,
+          isAgentSent,
+          sentByAgentTitle: metadata?.sent_by_agent_title as string | undefined,
+        };
+        break;
+      }
+    }
+
+    // Find last agent message (search from end)
+    let lastAgentMessage: string | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].info.role === "assistant") {
+        lastAgentMessage = extractMessageText(messages[i], MAX_SNIPPET_LENGTH);
+        break;
+      }
+    }
+
+    return c.json<AgentSnippetResponse>({
+      lastMessageAt,
+      lastUserMessage,
+      lastAgentMessage,
+    });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Unknown error" }, 500);
+  }
+}

--- a/projects/birdhouse/server/src/features/api/get-recent-agents.test.ts
+++ b/projects/birdhouse/server/src/features/api/get-recent-agents.test.ts
@@ -2,7 +2,6 @@
 // ABOUTME: Verifies limit param parsing, validation, and that it constrains DB rows before message fetches
 
 import { describe, expect, test } from "bun:test";
-import { createTestDeps } from "../../dependencies";
 import { initAgentsDB } from "../../lib/agents-db";
 import { createTestApp } from "../../test-utils";
 import { createRootAgent } from "../../test-utils/agent-factories";
@@ -10,11 +9,10 @@ import { getRecentAgents } from "./get-recent-agents";
 
 async function buildApp() {
   const agentsDB = await initAgentsDB(":memory:");
-  const deps = await createTestDeps();
-  deps.agentsDB = agentsDB;
 
   const app = await createTestApp({ agentsDb: agentsDB });
-  app.get("/agents/recent", (c) => getRecentAgents(c, deps));
+  // Handler only needs agentsDB — pass a minimal deps object
+  app.get("/agents/recent", (c) => getRecentAgents(c, { agentsDB }));
 
   return { app, agentsDB };
 }
@@ -62,6 +60,31 @@ describe("getRecentAgents - GET /agents/recent", () => {
       const body = (await res.json()) as { error: string };
       expect(body.error).toContain("limit");
     }
+  });
+
+  test("response contains only DB fields — no message fields", async () => {
+    const { app, agentsDB } = await buildApp();
+
+    createRootAgent(agentsDB, {
+      id: "agent_shape1",
+      session_id: "ses_shape1",
+      title: "Shape Test Agent",
+    });
+
+    const res = await app.request("/agents/recent");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { agents: Record<string, unknown>[] };
+    const agent = body.agents[0];
+    expect(agent).toBeDefined();
+    expect(agent).toHaveProperty("id");
+    expect(agent).toHaveProperty("title");
+    expect(agent).toHaveProperty("session_id");
+    expect(agent).toHaveProperty("parent_id");
+    expect(agent).toHaveProperty("tree_id");
+    expect(agent).not.toHaveProperty("lastMessageAt");
+    expect(agent).not.toHaveProperty("lastUserMessage");
+    expect(agent).not.toHaveProperty("lastAgentMessage");
   });
 
   test("omitting limit returns all recent agents without restriction", async () => {

--- a/projects/birdhouse/server/src/features/api/get-recent-agents.test.ts
+++ b/projects/birdhouse/server/src/features/api/get-recent-agents.test.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Tests for the GET /agents/recent endpoint
+// ABOUTME: Verifies limit param parsing, validation, and that it constrains DB rows before message fetches
+
+import { describe, expect, test } from "bun:test";
+import { createTestDeps } from "../../dependencies";
+import { initAgentsDB } from "../../lib/agents-db";
+import { createTestApp } from "../../test-utils";
+import { createRootAgent } from "../../test-utils/agent-factories";
+import { getRecentAgents } from "./get-recent-agents";
+
+async function buildApp() {
+  const agentsDB = await initAgentsDB(":memory:");
+  const deps = await createTestDeps();
+  deps.agentsDB = agentsDB;
+
+  const app = await createTestApp({ agentsDb: agentsDB });
+  app.get("/agents/recent", (c) => getRecentAgents(c, deps));
+
+  return { app, agentsDB };
+}
+
+describe("getRecentAgents - GET /agents/recent", () => {
+  test("returns 200 with agents array", async () => {
+    const { app } = await buildApp();
+
+    const res = await app.request("/agents/recent");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { agents: unknown[]; total: number };
+    expect(Array.isArray(body.agents)).toBe(true);
+    expect(typeof body.total).toBe("number");
+  });
+
+  test("accepts and applies ?limit= to constrain results", async () => {
+    const { app, agentsDB } = await buildApp();
+
+    // Insert 5 agents
+    for (let i = 1; i <= 5; i++) {
+      createRootAgent(agentsDB, {
+        id: `agent_lim${i}`,
+        session_id: `ses_lim${i}`,
+        title: `Limit Test Agent ${i}`,
+      });
+    }
+
+    const res = await app.request("/agents/recent?limit=2");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { agents: unknown[]; total: number };
+    expect(body.agents).toHaveLength(2);
+    expect(body.total).toBe(2);
+  });
+
+  test("returns 400 when limit is not a positive integer", async () => {
+    const { app } = await buildApp();
+
+    const badValues = ["0", "-1", "abc", "1.5"];
+
+    for (const val of badValues) {
+      const res = await app.request(`/agents/recent?limit=${val}`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("limit");
+    }
+  });
+
+  test("omitting limit returns all recent agents without restriction", async () => {
+    const { app, agentsDB } = await buildApp();
+
+    for (let i = 1; i <= 4; i++) {
+      createRootAgent(agentsDB, {
+        id: `agent_nolim${i}`,
+        session_id: `ses_nolim${i}`,
+        title: `No Limit Agent ${i}`,
+      });
+    }
+
+    const res = await app.request("/agents/recent");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agents: unknown[]; total: number };
+    expect(body.agents.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/projects/birdhouse/server/src/features/api/get-recent-agents.ts
+++ b/projects/birdhouse/server/src/features/api/get-recent-agents.ts
@@ -1,12 +1,8 @@
-// ABOUTME: Get recent agents with message context for @@ typeahead
-// ABOUTME: Returns agents from last 30 days with last message snippets
+// ABOUTME: Get recent agents for @@ typeahead — fast DB-only list
+// ABOUTME: Returns agents from last 30 days with no message loading; snippets are fetched per-agent separately
 
 import type { Context } from "hono";
-import { type Deps, getHarnessForAgent } from "../../dependencies";
-import type { BirdhouseMessage as Message } from "../../harness";
-
-// TODO(agent-search): Move search to db once we are setup for searching agents better
-const MAX_SNIPPET_LENGTH = 200;
+import type { Deps } from "../../dependencies";
 
 interface RecentAgentResponse {
   id: string;
@@ -14,38 +10,14 @@ interface RecentAgentResponse {
   session_id: string;
   parent_id: string | null;
   tree_id: string;
-  lastMessageAt: number | null;
-  lastUserMessage: {
-    text: string;
-    isAgentSent: boolean;
-    sentByAgentTitle?: string;
-  } | null;
-  lastAgentMessage: string | null;
 }
 
 /**
- * Extract text content from message parts
- * Joins all text parts and truncates to max length
+ * GET /api/agents/recent - Get recent agents for typeahead
+ * Returns agents sorted by updated_at desc. No message loading — callers fetch
+ * snippets per-agent via GET /api/agents/:id/messages/snippet.
  */
-function extractMessageText(message: Message, maxLength: number): string {
-  const textParts = message.parts
-    .filter((part) => part.type === "text")
-    .map((part) => (part as { type: "text"; text: string }).text);
-
-  const fullText = textParts.join(" ").trim();
-
-  if (fullText.length <= maxLength) {
-    return fullText;
-  }
-
-  return `${fullText.slice(0, maxLength - 3)}...`;
-}
-
-/**
- * GET /api/agents/recent - Get recent agents with message context
- * Returns agents sorted by updated_at desc, with last message snippets
- */
-export async function getRecentAgents(c: Context, deps: Pick<Deps, "agentsDB" | "harnesses">) {
+export async function getRecentAgents(c: Context, deps: Pick<Deps, "agentsDB">) {
   const { agentsDB } = deps;
 
   try {
@@ -66,91 +38,17 @@ export async function getRecentAgents(c: Context, deps: Pick<Deps, "agentsDB" | 
     // Get recent agents from database (filtered by query and limited if provided)
     const agents = agentsDB.getRecentAgents(query, limit);
 
-    // Fetch message context for each agent
-    const agentsWithContext: RecentAgentResponse[] = await Promise.all(
-      agents.map(async (agent) => {
-        try {
-          const harness = getHarnessForAgent(deps, agent);
-          const getMessagesFromHarness = harness.getMessages.bind(harness);
-          const messages = await getMessagesFromHarness(agent.session_id, 100);
-
-          if (messages.length === 0) {
-            return {
-              id: agent.id,
-              title: agent.title,
-              session_id: agent.session_id,
-              parent_id: agent.parent_id,
-              tree_id: agent.tree_id,
-              lastMessageAt: null,
-              lastUserMessage: null,
-              lastAgentMessage: null,
-            };
-          }
-
-          // Find the most recent message timestamp
-          const lastMessage = messages[messages.length - 1];
-          const lastMessageAt = lastMessage.info.time.created;
-
-          // Find last user message (search from end)
-          let lastUserMessage: RecentAgentResponse["lastUserMessage"] = null;
-          for (let i = messages.length - 1; i >= 0; i--) {
-            const msg = messages[i];
-            if (msg.info.role === "user") {
-              const text = extractMessageText(msg, MAX_SNIPPET_LENGTH);
-              // Check if this message was sent by an agent (not human)
-              // Look for sent_by_agent_id or sent_by_agent_title in first text part metadata
-              const firstTextPart = msg.parts.find((p) => p.type === "text") as
-                | { type: "text"; text: string; metadata?: Record<string, unknown> }
-                | undefined;
-              const metadata = firstTextPart?.metadata;
-              const isAgentSent = !!(metadata?.sent_by_agent_id || metadata?.sent_by_agent_title);
-              lastUserMessage = {
-                text,
-                isAgentSent,
-                sentByAgentTitle: metadata?.sent_by_agent_title as string | undefined,
-              };
-              break;
-            }
-          }
-
-          // Find last agent message (search from end)
-          let lastAgentMessage: string | null = null;
-          for (let i = messages.length - 1; i >= 0; i--) {
-            if (messages[i].info.role === "assistant") {
-              lastAgentMessage = extractMessageText(messages[i], MAX_SNIPPET_LENGTH);
-              break;
-            }
-          }
-
-          return {
-            id: agent.id,
-            title: agent.title,
-            session_id: agent.session_id,
-            parent_id: agent.parent_id,
-            tree_id: agent.tree_id,
-            lastMessageAt,
-            lastUserMessage,
-            lastAgentMessage,
-          };
-        } catch (_error) {
-          // If message fetch fails, return agent with null message fields
-          return {
-            id: agent.id,
-            title: agent.title,
-            session_id: agent.session_id,
-            parent_id: agent.parent_id,
-            tree_id: agent.tree_id,
-            lastMessageAt: null,
-            lastUserMessage: null,
-            lastAgentMessage: null,
-          };
-        }
-      }),
-    );
+    const response: RecentAgentResponse[] = agents.map((agent) => ({
+      id: agent.id,
+      title: agent.title,
+      session_id: agent.session_id,
+      parent_id: agent.parent_id,
+      tree_id: agent.tree_id,
+    }));
 
     return c.json({
-      agents: agentsWithContext,
-      total: agentsWithContext.length,
+      agents: response,
+      total: response.length,
     });
   } catch (error) {
     return c.json({ error: error instanceof Error ? error.message : "Unknown error" }, 500);

--- a/projects/birdhouse/server/src/features/api/get-recent-agents.ts
+++ b/projects/birdhouse/server/src/features/api/get-recent-agents.ts
@@ -52,8 +52,19 @@ export async function getRecentAgents(c: Context, deps: Pick<Deps, "agentsDB" | 
     // Parse optional query parameter
     const query = c.req.query("q") || "";
 
-    // Get recent agents from database (filtered by query if provided)
-    const agents = agentsDB.getRecentAgents(query);
+    // Parse optional limit parameter — must be a positive integer when provided
+    let limit: number | undefined;
+    const limitParam = c.req.query("limit");
+    if (limitParam !== undefined) {
+      const parsed = Number(limitParam);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        return c.json({ error: "limit must be a positive integer" }, 400);
+      }
+      limit = parsed;
+    }
+
+    // Get recent agents from database (filtered by query and limited if provided)
+    const agents = agentsDB.getRecentAgents(query, limit);
 
     // Fetch message context for each agent
     const agentsWithContext: RecentAgentResponse[] = await Promise.all(

--- a/projects/birdhouse/server/src/lib/agents-db.test.ts
+++ b/projects/birdhouse/server/src/lib/agents-db.test.ts
@@ -2076,4 +2076,68 @@ describe("AgentsDB", () => {
       });
     });
   });
+
+  // ============================================================================
+  // getRecentAgents
+  // ============================================================================
+
+  describe("getRecentAgents", () => {
+    function insertRecentAgent(db: AgentsDB, id: string, sessionId: string, title: string, updatedAtOffset = 0) {
+      const now = Date.now();
+      return db.insertAgent({
+        id,
+        session_id: sessionId,
+        parent_id: null,
+        tree_id: id,
+        level: 0,
+        title,
+        project_id: "test-project",
+        directory: "/test",
+        model: "anthropic/claude-sonnet-4",
+        cloned_from: null,
+        cloned_at: null,
+        archived_at: null,
+        created_at: now + updatedAtOffset,
+        updated_at: now + updatedAtOffset,
+      });
+    }
+
+    test("returns all recent agents when no limit is provided", () => {
+      insertRecentAgent(db, "agent_a", "ses_a", "Agent A", -1000);
+      insertRecentAgent(db, "agent_b", "ses_b", "Agent B", -2000);
+      insertRecentAgent(db, "agent_c", "ses_c", "Agent C", -3000);
+
+      const results = db.getRecentAgents();
+      expect(results.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test("limits results to the given number when limit is provided", () => {
+      insertRecentAgent(db, "agent_l1", "ses_l1", "Limit Agent 1", -1000);
+      insertRecentAgent(db, "agent_l2", "ses_l2", "Limit Agent 2", -2000);
+      insertRecentAgent(db, "agent_l3", "ses_l3", "Limit Agent 3", -3000);
+
+      const results = db.getRecentAgents(undefined, 2);
+      expect(results).toHaveLength(2);
+    });
+
+    test("limit=1 returns only the most recently updated agent", () => {
+      insertRecentAgent(db, "agent_newest", "ses_newest", "Newest Agent", -500);
+      insertRecentAgent(db, "agent_older", "ses_older", "Older Agent", -5000);
+
+      const results = db.getRecentAgents(undefined, 1);
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("agent_newest");
+    });
+
+    test("limit applies before fuzzy filtering", () => {
+      // Insert 3 agents that all match "Agent", limit to 2
+      insertRecentAgent(db, "agent_m1", "ses_m1", "Match Agent One", -1000);
+      insertRecentAgent(db, "agent_m2", "ses_m2", "Match Agent Two", -2000);
+      insertRecentAgent(db, "agent_m3", "ses_m3", "Match Agent Three", -3000);
+
+      // With limit=2, only the 2 most recent rows come out of SQL before fuzzy filter
+      const results = db.getRecentAgents("Agent", 2);
+      expect(results.length).toBeLessThanOrEqual(2);
+    });
+  });
 });

--- a/projects/birdhouse/server/src/lib/agents-db.ts
+++ b/projects/birdhouse/server/src/lib/agents-db.ts
@@ -152,9 +152,9 @@ export interface AgentsDB {
     sortDir?: SortDirection,
   ): { rows: AgentRow[]; matchedAgentIds: string[] };
 
-  /** Get recent agents from last 30 days, optionally filtered by query */
+  /** Get recent agents from last 30 days, optionally filtered by query and limited in count */
   // TODO(agent-search): Revisit this when we implement the new search feature
-  getRecentAgents(query?: string): AgentRow[];
+  getRecentAgents(query?: string, limit?: number): AgentRow[];
 
   /** Get all agents that belong to the same tree */
   getAgentsByTreeId(treeId: string): AgentRow[];
@@ -709,11 +709,13 @@ export function createAgentsDB(dbPath: string, existingDb?: Database): AgentsDB 
       return { rows, matchedAgentIds };
     },
 
-    getRecentAgents(query?: string): AgentRow[] {
+    getRecentAgents(query?: string, limit?: number): AgentRow[] {
       // TODO(agent-search): Move search to db once we are setup for searching agents better
       // Get agents from last 30 days to provide relevant recent context
       // while keeping query bounded (avoids fetching entire db for search)
       const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+
+      const limitClause = limit !== undefined ? `LIMIT ${limit}` : "";
 
       const sql = `
         SELECT 
@@ -724,6 +726,7 @@ export function createAgentsDB(dbPath: string, existingDb?: Database): AgentsDB 
         WHERE archived_at IS NULL
           AND updated_at > ?
         ORDER BY updated_at DESC
+        ${limitClause}
       `;
 
       const rows = db.prepare(sql).all(thirtyDaysAgo) as AgentRow[];

--- a/projects/birdhouse/server/src/routes/agents.recent.test.ts
+++ b/projects/birdhouse/server/src/routes/agents.recent.test.ts
@@ -1,9 +1,8 @@
 // ABOUTME: Unit tests for GET /api/agents/recent endpoint
-// ABOUTME: Tests recent agent listing with message context and search filtering
+// ABOUTME: Tests recent agent listing and search filtering — DB rows only, no message fields
 
 import { describe, expect, test } from "bun:test";
 import { createTestDeps, withDeps } from "../dependencies";
-import type { BirdhouseMessage as Message } from "../harness";
 import { initAgentsDB } from "../lib/agents-db";
 import { withWorkspaceContext } from "../test-utils";
 import { createChildAgent, createRootAgent } from "../test-utils/agent-factories";
@@ -16,100 +15,8 @@ interface RecentAgentResponse {
     session_id: string;
     parent_id: string | null;
     tree_id: string;
-    lastMessageAt: number | null;
-    lastUserMessage: {
-      text: string;
-      isAgentSent: boolean;
-      sentByAgentTitle?: string;
-    } | null;
-    lastAgentMessage: string | null;
   }>;
   total: number;
-}
-
-function makeUserMessage(
-  id: string,
-  sessionID: string,
-  created: number,
-  text: string,
-  metadata?: Record<string, unknown>,
-): Message {
-  return {
-    info: {
-      id,
-      sessionID,
-      role: "user",
-      time: { created },
-    },
-    parts: [
-      {
-        id: `${id}_part_text`,
-        sessionID,
-        messageID: id,
-        type: "text",
-        text,
-        ...(metadata ? { metadata } : {}),
-      },
-    ],
-  };
-}
-
-function makeAssistantMessage(id: string, sessionID: string, created: number, text: string): Message {
-  return {
-    info: {
-      id,
-      sessionID,
-      role: "assistant",
-      time: { created },
-      parentID: `${id}_parent`,
-      modelID: "claude-sonnet-4",
-      providerID: "anthropic",
-    },
-    parts: [
-      {
-        id: `${id}_part_text`,
-        sessionID,
-        messageID: id,
-        type: "text",
-        text,
-      },
-    ],
-  };
-}
-
-function makeToolPartMessage(id: string, sessionID: string, created: number): Message {
-  return {
-    info: {
-      id,
-      sessionID,
-      role: "user",
-      time: { created },
-    },
-    parts: [
-      {
-        id: `${id}_part_text_1`,
-        sessionID,
-        messageID: id,
-        type: "text",
-        text: "First part ",
-      },
-      {
-        id: `${id}_part_tool`,
-        sessionID,
-        messageID: id,
-        type: "tool",
-        tool: "read",
-        state: { file: "test.txt" },
-      },
-      {
-        id: `${id}_part_text_2`,
-        sessionID,
-        messageID: id,
-        type: "text",
-        text: "second part",
-      },
-    ],
-  };
 }
 
 describe("GET /api/agents/recent - Basic behavior", () => {
@@ -382,200 +289,8 @@ describe("GET /api/agents/recent - Search filtering", () => {
   });
 });
 
-describe("GET /api/agents/recent - Message context", () => {
-  test("returns agent with message context from OpenCode", async () => {
-    const agentsDB = await initAgentsDB(":memory:");
-    const now = Date.now();
-
-    createRootAgent(agentsDB, {
-      id: "agent_with_messages",
-      session_id: "ses_messages",
-      title: "Agent With Messages",
-      created_at: now,
-      updated_at: now,
-    });
-
-    const deps = await createTestDeps({
-      getMessages: async () => [
-        makeUserMessage("msg_user_1", "ses_messages", now - 2000, "First user message here"),
-        makeAssistantMessage("msg_assistant_1", "ses_messages", now - 1000, "Agent response here"),
-        makeUserMessage("msg_user_2", "ses_messages", now, "Latest user message content"),
-      ],
-    });
-    deps.agentsDB = agentsDB;
-
-    await withDeps(deps, async () => {
-      const app = await withWorkspaceContext(createAgentRoutes, { agentsDb: agentsDB });
-      const res = await app.request("/recent");
-
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as RecentAgentResponse;
-      expect(data.total).toBe(1);
-
-      const result = data.agents[0];
-      expect(result.lastMessageAt).toBe(now);
-      expect(result.lastUserMessage).toEqual({ text: "Latest user message content", isAgentSent: false });
-      expect(result.lastAgentMessage).toBe("Agent response here");
-    });
-  });
-
-  test("truncates long messages to 200 chars with ellipsis", async () => {
-    const agentsDB = await initAgentsDB(":memory:");
-    const now = Date.now();
-
-    createRootAgent(agentsDB, {
-      id: "agent_long_message",
-      session_id: "ses_long",
-      title: "Agent With Long Message",
-      created_at: now,
-      updated_at: now,
-    });
-
-    const longMessage = "a".repeat(250);
-
-    const deps = await createTestDeps({
-      getMessages: async () => [makeUserMessage("msg_long", "ses_long", now, longMessage)],
-    });
-    deps.agentsDB = agentsDB;
-
-    await withDeps(deps, async () => {
-      const app = await withWorkspaceContext(createAgentRoutes, { agentsDb: agentsDB });
-      const res = await app.request("/recent");
-
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as RecentAgentResponse;
-      expect(data.agents[0].lastUserMessage).toEqual({ text: `${"a".repeat(197)}...`, isAgentSent: false });
-    });
-  });
-
-  test("returns null message fields when agent has no messages", async () => {
-    const agentsDB = await initAgentsDB(":memory:");
-    const now = Date.now();
-
-    createRootAgent(agentsDB, {
-      id: "agent_no_messages",
-      session_id: "ses_no_messages",
-      title: "Agent With No Messages",
-      created_at: now,
-      updated_at: now,
-    });
-
-    const deps = await createTestDeps({
-      getMessages: async () => [],
-    });
-    deps.agentsDB = agentsDB;
-
-    await withDeps(deps, async () => {
-      const app = await withWorkspaceContext(createAgentRoutes, { agentsDb: agentsDB });
-      const res = await app.request("/recent");
-
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as RecentAgentResponse;
-      expect(data.agents[0].lastMessageAt).toBeNull();
-      expect(data.agents[0].lastUserMessage).toBeNull();
-      expect(data.agents[0].lastAgentMessage).toBeNull();
-    });
-  });
-
-  test("returns null message fields when getMessages throws", async () => {
-    const agentsDB = await initAgentsDB(":memory:");
-    const now = Date.now();
-
-    createRootAgent(agentsDB, {
-      id: "agent_error",
-      session_id: "ses_error",
-      title: "Agent With Error",
-      created_at: now,
-      updated_at: now,
-    });
-
-    const deps = await createTestDeps({
-      getMessages: async () => {
-        throw new Error("Failed to fetch messages");
-      },
-    });
-    deps.agentsDB = agentsDB;
-
-    await withDeps(deps, async () => {
-      const app = await withWorkspaceContext(createAgentRoutes, { agentsDb: agentsDB });
-      const res = await app.request("/recent");
-
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as RecentAgentResponse;
-      // Agent should still be included with null message fields
-      expect(data.total).toBe(1);
-      expect(data.agents[0].id).toBe("agent_error");
-      expect(data.agents[0].lastMessageAt).toBeNull();
-      expect(data.agents[0].lastUserMessage).toBeNull();
-      expect(data.agents[0].lastAgentMessage).toBeNull();
-    });
-  });
-
-  test("combines multiple text parts into single snippet", async () => {
-    const agentsDB = await initAgentsDB(":memory:");
-    const now = Date.now();
-
-    createRootAgent(agentsDB, {
-      id: "agent_multi_part",
-      session_id: "ses_multi",
-      title: "Agent With Multi Part Message",
-      created_at: now,
-      updated_at: now,
-    });
-
-    const deps = await createTestDeps({
-      getMessages: async () => [makeToolPartMessage("msg_multi", "ses_multi", now)],
-    });
-    deps.agentsDB = agentsDB;
-
-    await withDeps(deps, async () => {
-      const app = await withWorkspaceContext(createAgentRoutes, { agentsDb: agentsDB });
-      const res = await app.request("/recent");
-
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as RecentAgentResponse;
-      // Should join text parts with space separator and skip tool parts
-      expect(data.agents[0].lastUserMessage).toEqual({ text: "First part  second part", isAgentSent: false });
-    });
-  });
-
-  test("finds last user and agent messages independently", async () => {
-    const agentsDB = await initAgentsDB(":memory:");
-    const now = Date.now();
-
-    createRootAgent(agentsDB, {
-      id: "agent_mixed",
-      session_id: "ses_mixed",
-      title: "Agent With Mixed Messages",
-      created_at: now,
-      updated_at: now,
-    });
-
-    const deps = await createTestDeps({
-      getMessages: async () => [
-        makeUserMessage("msg_user_old", "ses_mixed", now - 3000, "Oldest user"),
-        makeAssistantMessage("msg_assistant_old", "ses_mixed", now - 2000, "First agent reply"),
-        makeUserMessage("msg_user_mid", "ses_mixed", now - 1000, "Middle user"),
-        makeAssistantMessage("msg_assistant_new", "ses_mixed", now, "Latest agent reply"),
-      ],
-    });
-    deps.agentsDB = agentsDB;
-
-    await withDeps(deps, async () => {
-      const app = await withWorkspaceContext(createAgentRoutes, { agentsDb: agentsDB });
-      const res = await app.request("/recent");
-
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as RecentAgentResponse;
-      expect(data.agents[0].lastMessageAt).toBe(now);
-      expect(data.agents[0].lastUserMessage).toEqual({ text: "Middle user", isAgentSent: false });
-      expect(data.agents[0].lastAgentMessage).toBe("Latest agent reply");
-    });
-  });
-});
-
 describe("GET /api/agents/recent - Response fields", () => {
-  test("includes all required response fields", async () => {
+  test("includes all required response fields — no message fields", async () => {
     const agentsDB = await initAgentsDB(":memory:");
     const now = Date.now();
 
@@ -603,9 +318,10 @@ describe("GET /api/agents/recent - Response fields", () => {
       expect(agent.session_id).toBe("ses_parent");
       expect(agent.parent_id).toBeNull();
       expect(agent.tree_id).toBe(parent.tree_id);
-      expect(agent).toHaveProperty("lastMessageAt");
-      expect(agent).toHaveProperty("lastUserMessage");
-      expect(agent).toHaveProperty("lastAgentMessage");
+      // Message fields are no longer in this response — fetched separately via /snippet
+      expect(agent).not.toHaveProperty("lastMessageAt");
+      expect(agent).not.toHaveProperty("lastUserMessage");
+      expect(agent).not.toHaveProperty("lastAgentMessage");
     });
   });
 

--- a/projects/birdhouse/server/src/routes/agents.ts
+++ b/projects/birdhouse/server/src/routes/agents.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { getHarnessForAgent } from "../dependencies";
 import * as handlers from "../features/api";
 import { archive } from "../features/api/archive";
+import { getAgentSnippet } from "../features/api/get-agent-snippet";
 import { getAgentQuestions, replyToAgentQuestion } from "../features/api/question";
 import { unarchive } from "../features/api/unarchive";
 import { getDepsFromContext } from "../lib/context-deps";
@@ -110,6 +111,9 @@ export function createAgentRoutes() {
 
   // GET /api/agents/:id/export - Export agent timeline as markdown
   app.get("/:id/export", (c) => handlers.exportMarkdown(c, getDepsFromContext(c)));
+
+  // GET /api/agents/:id/messages/snippet - Get last message snippet for typeahead preview
+  app.get("/:id/messages/snippet", (c) => getAgentSnippet(c, getDepsFromContext(c)));
 
   // GET /api/agents/:id/messages - Get messages for agent
   app.get("/:id/messages", (c) => handlers.getMessages(c, getDepsFromContext(c)));


### PR DESCRIPTION
## What's New

### Features
- **Agent Search dialog opens instantly** on large workspaces. Previously, opening the dialog triggered a getMessages() call for every agent from the last 30 days before responding — hundreds of parallel harness calls on busy workspaces. Now the dialog loads a fast DB-only list and fetches message previews lazily per card as they become visible.

---

## Technical Changes

### Infrastructure

**Server**
- `GET /api/agents/recent` now returns DB rows only (id, title, session_id, parent_id, tree_id) — no harness calls, no Promise.all. Response time drops from O(N x harness latency) to a single SQLite query.
- New `GET /api/agents/:id/messages/snippet` returns lastMessageAt, lastUserMessage, and lastAgentMessage for one agent. Used by the dialog to load previews on demand.
- New `?limit=N` param on `GET /api/agents/recent` applies LIMIT in SQL before any filtering. The dialog passes limit=50.
- `agents-db.ts`: `getRecentAgents(query?, limit?)` — limit applied at the SQL level.

**Frontend**
- `fetchRecentAgentsList` (fast, no message fields) and `fetchRecentAgentSnippet(agentId)` replace the old `fetchRecentAgents`.
- `RecentAgentCard` owns its own snippet state via `createResource` keyed off a `shouldLoadSnippet` signal. An `IntersectionObserver` (root = dialog scroll container, rootMargin 120px, one-shot) drives the signal. Cards show a skeleton until their snippet arrives.
- Snippet loading is suppressed while Agent Search is not the top-most modal layer.
- `WorkspaceLayout`: global Cmd+O / Ctrl+O shortcut to open Agent Search.
- `AgentTypeahead`: updated to accept the slimmer agent shape from the list endpoint.

### Code Quality
- Removed client-side slice after fetch — limit now enforced server-side.
- Deleted the "Message context" test block from `agents.recent.test.ts`; those behaviors now live in `get-agent-snippet.test.ts`.

## Testing

TDD throughout: failing tests written before each implementation step.

New test files: `get-agent-snippet.test.ts` and `get-recent-agents.test.ts` (server); `AgentSearchDialog.test.tsx` extended with `MockIntersectionObserver` covering: visible card triggers snippet fetch, non-visible card does not, skeleton while loading, snippet replaces skeleton, silent failure leaves blank preview.

- Server: 666 passing, 4 skipped
- Frontend: 712 passing, 3 skipped