### PR TITLE
Skill library modal scrolling - keep panes scrollable

### DIFF
--- a/projects/birdhouse/frontend/src/components/AgentModal.layer.test.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentModal.layer.test.tsx
@@ -145,4 +145,17 @@ describe("AgentModal nested dialog layers", () => {
     expect(liveMessagesLifecycle.mounts.get("agent-1")).toBe(1);
     expect(liveMessagesLifecycle.unmounts.get("agent-1") ?? 0).toBe(0);
   });
+
+  it("does not enable document scroll locking for agent modals", async () => {
+    render(() => <RecursiveModalHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-modal-agent-1")).toBeInTheDocument();
+    });
+
+    expect(document.body.style.overflow).toBe("");
+    expect(document.body.style.paddingRight).toBe("");
+    expect(document.documentElement.style.overflow).toBe("");
+    expect(document.documentElement.style.paddingRight).toBe("");
+  });
 });

--- a/projects/birdhouse/frontend/src/components/AgentModal.tsx
+++ b/projects/birdhouse/frontend/src/components/AgentModal.tsx
@@ -37,6 +37,8 @@ const AgentModal: Component<AgentModalProps> = (props) => {
       closeOnEscapeKeyDown={props.isTop}
       closeOnOutsidePointer={false}
       closeOnOutsideFocus={false}
+      preventScroll={false}
+      restoreScrollPosition={false}
     >
       <Dialog.Portal mount={document.body}>
         <Dialog.Overlay class="fixed inset-0 bg-black/20" style={{ "z-index": baseZIndex }} />

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
@@ -121,14 +121,14 @@ describe("SkillListPane", () => {
     render(() => <Wrapper />);
 
     await waitFor(() => {
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
     });
 
     scrollIntoView.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Select release notes" }));
 
     await waitFor(() => {
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
     });
   });
 });

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
@@ -3,7 +3,7 @@
 
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createMemo, createSignal } from "solid-js";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { filterSkills } from "../utils/skill-library-filtering";
 import SkillListPane from "./SkillListPane";
 
@@ -33,6 +33,10 @@ const skills = [
 ];
 
 describe("SkillListPane", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("updates search and filter controls while showing a flat filtered list", async () => {
     const onSelectSkill = vi.fn();
 
@@ -86,5 +90,45 @@ describe("SkillListPane", () => {
     fireEvent.click(screen.getByRole("button", { name: /release-notes-from-branch/i }));
 
     expect(onSelectSkill).toHaveBeenCalledWith("release-notes-from-branch");
+  });
+
+  it("scrolls the selected skill into view", async () => {
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+
+    const Wrapper = () => {
+      const [selectedSkillId, setSelectedSkillId] = createSignal<string | null>(skills[0]?.id ?? null);
+
+      return (
+        <>
+          <button type="button" onClick={() => setSelectedSkillId("release-notes-from-branch")}>
+            Select release notes
+          </button>
+          <SkillListPane
+            skills={skills}
+            filteredSkills={skills}
+            searchQuery=""
+            scopeFilter="all"
+            selectedSkillId={selectedSkillId()}
+            onSearchQueryChange={() => {}}
+            onScopeFilterChange={() => {}}
+            onSelectSkill={setSelectedSkillId}
+          />
+        </>
+      );
+    };
+
+    render(() => <Wrapper />);
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    });
+
+    scrollIntoView.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Select release notes" }));
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    });
   });
 });

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
@@ -3,7 +3,7 @@
 
 import Popover from "corvu/popover";
 import { Filter, Search } from "lucide-solid";
-import { type Component, For, Show } from "solid-js";
+import { type Component, createEffect, For, on, Show } from "solid-js";
 import { Button } from "../../components/ui";
 import { useZIndex } from "../../contexts/ZIndexContext";
 import { cardSurfaceFlat } from "../../styles/containerStyles";
@@ -23,6 +23,7 @@ export interface SkillListPaneProps {
 
 const SkillListPane: Component<SkillListPaneProps> = (props) => {
   const baseZIndex = useZIndex();
+  let selectedSkillButton: HTMLButtonElement | undefined;
 
   const resultCountLabel = () => {
     const count = props.filteredSkills.length;
@@ -42,6 +43,18 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
     { value: "workspace", label: "Workspace" },
     { value: "global", label: "Global" },
   ];
+
+  createEffect(
+    on([() => props.selectedSkillId, () => props.filteredSkills], ([selectedSkillId]) => {
+      if (!selectedSkillId) {
+        return;
+      }
+
+      queueMicrotask(() => {
+        selectedSkillButton?.scrollIntoView({ block: "nearest" });
+      });
+    }),
+  );
 
   return (
     <div class="flex flex-col h-full overflow-hidden">
@@ -129,6 +142,11 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
             {(skill) => (
               <button
                 type="button"
+                ref={(el) => {
+                  if (props.selectedSkillId === skill.id) {
+                    selectedSkillButton = el;
+                  }
+                }}
                 onClick={() => props.onSelectSkill(skill.id)}
                 class="w-full text-left px-3 py-4 transition-colors border-b border-border-muted/40 last:border-b-0"
                 classList={{

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
@@ -51,7 +51,7 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
       }
 
       queueMicrotask(() => {
-        selectedSkillButton?.scrollIntoView({ block: "nearest" });
+        selectedSkillButton?.scrollIntoView({ block: "start" });
       });
     }),
   );


### PR DESCRIPTION
## What's New

### ✨ Features
- When the Skills Library opens to a referenced skill, the selected skill now auto-scrolls into view at the top of the left list pane instead of appearing offscreen or only barely visible at the bottom edge.

### 🐛 Fixes
- Fixed the nested modal scroll bug where opening the Skills Library from inside an agent modal left the skill list and skill detail panes unscrollable.

---

## Technical Changes

### 🧹 Code Quality
- Disabled Corvu document scroll locking in `AgentModal` so nested dialogs can keep using their own internal scroll containers.
- Added a regression test proving agent modals no longer force document-level scroll locking.
- Added selected-item scrolling in `SkillListPane` using `scrollIntoView({ block: "start" })` when the library selection changes.
- Added regression coverage for the skill list auto-scroll behavior.

## Testing
- `bun run check` in `projects/birdhouse/frontend`
- Targeted Vitest coverage for:
  - `src/components/AgentModal.layer.test.tsx`
  - `src/skills/components/SkillListPane.test.tsx`
  - `src/skills/components/SkillLibraryDialog.test.tsx`
- Manual live-dev-server validation on `http://127.0.0.1:50120`
- Browser automation validation confirmed:
  - the skill list pane scrolls inside the nested Skills Library modal
  - the skill detail pane scrolls independently
  - the selected skill opens with selected styling intact
  - the selected skill is auto-scrolled into view at the top of the left pane
