### PR TITLE
File viewer - add generic read-only dialog

### DIFF
--- a/projects/birdhouse/frontend/src/components/ui/TextEditor.tsx
+++ b/projects/birdhouse/frontend/src/components/ui/TextEditor.tsx
@@ -14,6 +14,7 @@ export interface TextEditorProps {
   language: string;
   onBlur?: () => void;
   disabled?: boolean;
+  chrome?: boolean;
   height?: string;
   placeholder?: string;
   ariaLabel?: string;
@@ -134,7 +135,7 @@ const TextEditor: Component<TextEditorProps> = (props) => {
 
   return (
     <div
-      class={`relative overflow-hidden rounded-lg border border-border bg-surface ${props.class ?? ""}`.trim()}
+      class={`relative overflow-hidden ${props.chrome === false ? "" : "rounded-lg border border-border bg-surface"} ${props.class ?? ""}`.trim()}
       style={{ height: props.height ?? "16rem" }}
     >
       <Show when={props.placeholder && !focused() && props.value.length === 0}>
@@ -144,7 +145,9 @@ const TextEditor: Component<TextEditorProps> = (props) => {
       </Show>
       <div class="h-full w-full" ref={containerRef} />
       <Show when={!ready()}>
-        <div class="pointer-events-none absolute inset-0 bg-surface" />
+        <div
+          class={`pointer-events-none absolute inset-0 ${props.chrome === false ? "bg-transparent" : "bg-surface"}`}
+        />
       </Show>
     </div>
   );

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
@@ -120,6 +120,11 @@ describe("FileViewerDialog", () => {
       />
     ));
 
+    expect(screen.getByRole("button", { name: "Reveal file in Finder" })).toHaveAttribute(
+      "title",
+      "Reveal file in Finder",
+    );
+
     fireEvent.click(screen.getByRole("button", { name: "Reveal file in Finder" }));
 
     await waitFor(() => {

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
@@ -5,8 +5,17 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
 import FileViewerDialog from "./FileViewerDialog";
 
+const { revealFileViewerPathMock } = vi.hoisted(() => ({
+  revealFileViewerPathMock: vi.fn(),
+}));
+
 vi.mock("../../contexts/ZIndexContext", () => ({
   useZIndex: () => 100,
+}));
+
+vi.mock("../services/file-viewer-api", () => ({
+  fetchFileViewerContent: vi.fn(),
+  revealFileViewerPath: (workspaceId: string, path: string) => revealFileViewerPathMock(workspaceId, path),
 }));
 
 describe("FileViewerDialog", () => {
@@ -59,6 +68,31 @@ describe("FileViewerDialog", () => {
 
     await waitFor(() => {
       expect(dialog.textContent).toContain("export const answer = 42;");
+    });
+  });
+
+  it("reveals the current file path in Finder", async () => {
+    revealFileViewerPathMock.mockResolvedValueOnce(undefined);
+
+    render(() => (
+      <FileViewerDialog
+        open={true}
+        onOpenChange={() => {}}
+        file={{
+          path: "/Users/test/references/notes.md",
+          name: "notes.md",
+          content: "# Notes\n\nHello world.",
+          language: "markdown",
+          isMarkdown: true,
+        }}
+        workspaceId="ws_test"
+      />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Reveal file in Finder" }));
+
+    await waitFor(() => {
+      expect(revealFileViewerPathMock).toHaveBeenCalledWith("ws_test", "/Users/test/references/notes.md");
     });
   });
 });

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
@@ -6,8 +6,9 @@ import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FileViewerDialog from "./FileViewerDialog";
 
-const { revealFileViewerPathMock } = vi.hoisted(() => ({
+const { revealFileViewerPathMock, textEditorMock } = vi.hoisted(() => ({
   revealFileViewerPathMock: vi.fn(),
+  textEditorMock: vi.fn(),
 }));
 
 vi.mock("../../contexts/ZIndexContext", () => ({
@@ -19,9 +20,21 @@ vi.mock("../services/file-viewer-api", () => ({
   revealFileViewerPath: (workspaceId: string, path: string) => revealFileViewerPathMock(workspaceId, path),
 }));
 
+vi.mock("../../components/ui/TextEditor", () => ({
+  default: (props: { value: string; language: string; disabled?: boolean; height?: string; ariaLabel?: string }) => {
+    textEditorMock(props);
+    return (
+      <div data-testid="text-editor" data-language={props.language} data-disabled={props.disabled ? "true" : "false"}>
+        {props.value}
+      </div>
+    );
+  },
+}));
+
 describe("FileViewerDialog", () => {
   beforeEach(() => {
     revealFileViewerPathMock.mockReset();
+    textEditorMock.mockReset();
   });
 
   it("shows markdown in rich mode by default and can toggle to raw mode", async () => {
@@ -46,9 +59,14 @@ describe("FileViewerDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Raw" }));
 
     expect(screen.getByRole("button", { name: "Raw" })).toHaveAttribute("aria-pressed", "true");
-    await waitFor(() => {
-      expect(screen.getByText((content) => content.includes("Hello world."))).toBeInTheDocument();
-    });
+    expect(screen.getByTestId("text-editor")).toHaveTextContent("# Notes Hello world.");
+    expect(textEditorMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        value: "# Notes\n\nHello world.",
+        language: "markdown",
+        disabled: true,
+      }),
+    );
   });
 
   it("renders non-markdown files without the rich raw toggle", async () => {
@@ -69,11 +87,14 @@ describe("FileViewerDialog", () => {
     expect(screen.queryByRole("button", { name: "Rich" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Raw" })).not.toBeInTheDocument();
 
-    const dialog = screen.getByRole("dialog");
-
-    await waitFor(() => {
-      expect(dialog.textContent).toContain("export const answer = 42;");
-    });
+    expect(screen.getByTestId("text-editor")).toHaveTextContent("export const answer = 42;");
+    expect(textEditorMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        value: "export const answer = 42;",
+        language: "typescript",
+        disabled: true,
+      }),
+    );
   });
 
   it("reveals the current file path in Finder", async () => {

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
@@ -2,7 +2,8 @@
 // ABOUTME: Verifies markdown rich/raw mode and code-view fallback for non-markdown files.
 
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import FileViewerDialog from "./FileViewerDialog";
 
 const { revealFileViewerPathMock } = vi.hoisted(() => ({
@@ -19,6 +20,10 @@ vi.mock("../services/file-viewer-api", () => ({
 }));
 
 describe("FileViewerDialog", () => {
+  beforeEach(() => {
+    revealFileViewerPathMock.mockReset();
+  });
+
   it("shows markdown in rich mode by default and can toggle to raw mode", async () => {
     render(() => (
       <FileViewerDialog
@@ -93,6 +98,69 @@ describe("FileViewerDialog", () => {
 
     await waitFor(() => {
       expect(revealFileViewerPathMock).toHaveBeenCalledWith("ws_test", "/Users/test/references/notes.md");
+    });
+  });
+
+  it("shows reveal failures in the dialog instead of rejecting unhandled", async () => {
+    revealFileViewerPathMock.mockRejectedValueOnce(new Error("Failed to reveal file: Bad Request - nope"));
+
+    render(() => (
+      <FileViewerDialog
+        open={true}
+        onOpenChange={() => {}}
+        file={{
+          path: "/Users/test/references/notes.md",
+          name: "notes.md",
+          content: "# Notes\n\nHello world.",
+          language: "markdown",
+          isMarkdown: true,
+        }}
+        workspaceId="ws_test"
+      />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Reveal file in Finder" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to reveal file: Bad Request - nope")).toBeInTheDocument();
+    });
+  });
+
+  it("resets markdown mode when the dialog reopens for the same file", async () => {
+    const markdownFile = {
+      path: "/Users/test/references/notes.md",
+      name: "notes.md",
+      content: "# Notes\n\nHello world.",
+      language: "markdown",
+      isMarkdown: true,
+    };
+
+    const Wrapper = () => {
+      const [open, setOpen] = createSignal(true);
+
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(false)}>
+            Close viewer
+          </button>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open viewer
+          </button>
+          <FileViewerDialog open={open()} onOpenChange={setOpen} file={markdownFile} workspaceId="ws_test" />
+        </>
+      );
+    };
+
+    render(() => <Wrapper />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+    expect(screen.getByRole("button", { name: "Raw" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close viewer" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open viewer" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Rich" })).toHaveAttribute("aria-pressed", "true");
     });
   });
 });

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
@@ -1,0 +1,64 @@
+// ABOUTME: Tests the generic file viewer dialog used for read-only file inspection.
+// ABOUTME: Verifies markdown rich/raw mode and code-view fallback for non-markdown files.
+
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import FileViewerDialog from "./FileViewerDialog";
+
+vi.mock("../../contexts/ZIndexContext", () => ({
+  useZIndex: () => 100,
+}));
+
+describe("FileViewerDialog", () => {
+  it("shows markdown in rich mode by default and can toggle to raw mode", async () => {
+    render(() => (
+      <FileViewerDialog
+        open={true}
+        onOpenChange={() => {}}
+        file={{
+          path: "/Users/test/references/notes.md",
+          name: "notes.md",
+          content: "# Notes\n\nHello world.",
+          language: "markdown",
+          isMarkdown: true,
+        }}
+        workspaceId="ws_test"
+      />
+    ));
+
+    expect(screen.getByRole("button", { name: "Rich" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("heading", { name: "Notes" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    expect(screen.getByRole("button", { name: "Raw" })).toHaveAttribute("aria-pressed", "true");
+    await waitFor(() => {
+      expect(screen.getByText((content) => content.includes("Hello world."))).toBeInTheDocument();
+    });
+  });
+
+  it("renders non-markdown files without the rich raw toggle", async () => {
+    render(() => (
+      <FileViewerDialog
+        open={true}
+        onOpenChange={() => {}}
+        file={{
+          path: "/Users/test/helpers.ts",
+          name: "helpers.ts",
+          content: "export const answer = 42;",
+          language: "typescript",
+          isMarkdown: false,
+        }}
+      />
+    ));
+
+    expect(screen.queryByRole("button", { name: "Rich" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Raw" })).not.toBeInTheDocument();
+
+    const dialog = screen.getByRole("dialog");
+
+    await waitFor(() => {
+      expect(dialog.textContent).toContain("export const answer = 42;");
+    });
+  });
+});

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.test.tsx
@@ -21,13 +21,16 @@ vi.mock("../services/file-viewer-api", () => ({
 }));
 
 vi.mock("../../components/ui/TextEditor", () => ({
-  default: (props: { value: string; language: string; disabled?: boolean; height?: string; ariaLabel?: string }) => {
+  default: (props: {
+    value: string;
+    language: string;
+    disabled?: boolean;
+    chrome?: boolean;
+    height?: string;
+    ariaLabel?: string;
+  }) => {
     textEditorMock(props);
-    return (
-      <div data-testid="text-editor" data-language={props.language} data-disabled={props.disabled ? "true" : "false"}>
-        {props.value}
-      </div>
-    );
+    return <div data-testid="text-editor">{props.value}</div>;
   },
 }));
 
@@ -65,6 +68,7 @@ describe("FileViewerDialog", () => {
         value: "# Notes\n\nHello world.",
         language: "markdown",
         disabled: true,
+        chrome: false,
       }),
     );
   });
@@ -93,6 +97,7 @@ describe("FileViewerDialog", () => {
         value: "export const answer = 42;",
         language: "typescript",
         disabled: true,
+        chrome: false,
       }),
     );
   });

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -31,9 +31,17 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
   const resolvedTheme = createMemo(() => resolveCodeTheme(codeTheme(), isDark()));
   const [markdownMode, setMarkdownMode] = createSignal<MarkdownViewMode>("rich");
   const [isRevealing, setIsRevealing] = createSignal(false);
+  const [revealError, setRevealError] = createSignal<string | null>(null);
 
   createEffect(() => {
+    const open = props.open;
     const file = props.file;
+
+    if (!open) {
+      return;
+    }
+
+    setRevealError(null);
     setMarkdownMode(file?.isMarkdown ? "rich" : "raw");
   });
 
@@ -43,8 +51,11 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
     }
 
     setIsRevealing(true);
+    setRevealError(null);
     try {
       await revealFileViewerPath(props.workspaceId, props.file.path);
+    } catch (err) {
+      setRevealError(err instanceof Error ? err.message : "Failed to reveal file");
     } finally {
       setIsRevealing(false);
     }
@@ -127,6 +138,11 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
           </div>
 
           <div class="flex-1 overflow-auto p-6 rounded-b-2xl">
+            <Show when={revealError()}>
+              <div class="mb-4 rounded-lg border border-danger bg-danger/10 p-3 text-sm text-danger">
+                {revealError()}
+              </div>
+            </Show>
             <Show when={!props.loading} fallback={<div class="text-text-muted text-center py-12">Loading file...</div>}>
               <Show when={!props.error} fallback={<div class="text-danger text-center py-12">{props.error}</div>}>
                 <Show

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -1,17 +1,15 @@
 // ABOUTME: Read-only dialog for viewing themed file contents with optional markdown rich/raw modes.
-// ABOUTME: Uses the shared markdown and code block renderers so file previews match the current app theme.
+// ABOUTME: Uses the shared markdown renderer and Monaco-based text editor so file previews match the current app theme.
 
 import Dialog from "corvu/dialog";
 import { FolderOpen } from "lucide-solid";
-import { type Component, createEffect, createMemo, createSignal, Show, Suspense } from "solid-js";
+import { type Component, createEffect, createMemo, createSignal, Show } from "solid-js";
 import { MarkdownRenderer } from "../../components/MarkdownRenderer";
-import CodeBlockContainer from "../../components/ui/CodeBlockContainer";
 import CopyButton from "../../components/ui/CopyButton";
 import IconButton from "../../components/ui/IconButton";
+import TextEditor from "../../components/ui/TextEditor";
 import { useZIndex } from "../../contexts/ZIndexContext";
-import { borderColor, cardSurface, cardSurfaceFlat } from "../../styles/containerStyles";
-import { codeTheme, isDark } from "../../theme";
-import { resolveCodeTheme } from "../../theme/codeThemes";
+import { borderColor, cardSurfaceFlat } from "../../styles/containerStyles";
 import { revealFileViewerPath } from "../services/file-viewer-api";
 import type { FileViewerFile } from "../types";
 
@@ -28,7 +26,6 @@ export interface FileViewerDialogProps {
 
 const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
   const baseZIndex = useZIndex();
-  const resolvedTheme = createMemo(() => resolveCodeTheme(codeTheme(), isDark()));
   const [markdownMode, setMarkdownMode] = createSignal<MarkdownViewMode>("rich");
   const [isRevealing, setIsRevealing] = createSignal(false);
   const [revealError, setRevealError] = createSignal<string | null>(null);
@@ -152,20 +149,17 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
                   <Show
                     when={props.file?.isMarkdown && markdownMode() === "rich"}
                     fallback={
-                      <Suspense
-                        fallback={
-                          <div class={`rounded ${cardSurface} overflow-hidden`}>
-                            <div class="h-24 bg-surface-raised animate-pulse" />
-                          </div>
-                        }
-                      >
-                        <CodeBlockContainer
-                          code={props.file?.content ?? ""}
+                      <div class="h-full overflow-hidden rounded-xl">
+                        <TextEditor
+                          value={props.file?.content ?? ""}
+                          onInput={() => {}}
                           language={props.file?.language || "text"}
-                          theme={resolvedTheme()}
-                          showCopyButton={true}
+                          disabled={true}
+                          height="100%"
+                          ariaLabel={`${title()} raw file content`}
+                          options={{ wordWrap: "off" }}
                         />
-                      </Suspense>
+                      </div>
                     }
                   >
                     <div class="rounded-xl border border-border-muted/70 bg-surface-overlay/40 p-6">

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -1,0 +1,145 @@
+// ABOUTME: Read-only dialog for viewing themed file contents with optional markdown rich/raw modes.
+// ABOUTME: Uses the shared markdown and code block renderers so file previews match the current app theme.
+
+import Dialog from "corvu/dialog";
+import { type Component, createEffect, createMemo, createSignal, Show, Suspense } from "solid-js";
+import { MarkdownRenderer } from "../../components/MarkdownRenderer";
+import CodeBlockContainer from "../../components/ui/CodeBlockContainer";
+import CopyButton from "../../components/ui/CopyButton";
+import { useZIndex } from "../../contexts/ZIndexContext";
+import { borderColor, cardSurface, cardSurfaceFlat } from "../../styles/containerStyles";
+import { codeTheme, isDark } from "../../theme";
+import { resolveCodeTheme } from "../../theme/codeThemes";
+import type { FileViewerFile } from "../types";
+
+type MarkdownViewMode = "rich" | "raw";
+
+export interface FileViewerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  file: FileViewerFile | null;
+  workspaceId?: string;
+  loading?: boolean;
+  error?: string | null;
+}
+
+const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
+  const baseZIndex = useZIndex();
+  const resolvedTheme = createMemo(() => resolveCodeTheme(codeTheme(), isDark()));
+  const [markdownMode, setMarkdownMode] = createSignal<MarkdownViewMode>("rich");
+
+  createEffect(() => {
+    const file = props.file;
+    setMarkdownMode(file?.isMarkdown ? "rich" : "raw");
+  });
+
+  const title = createMemo(() => props.file?.name ?? "File Viewer");
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      closeOnOutsideFocus={false}
+      preventScroll={false}
+      restoreScrollPosition={false}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay class="fixed inset-0 bg-black/60 backdrop-blur-sm" style={{ "z-index": baseZIndex }} />
+        <Dialog.Content
+          class={`fixed rounded-2xl ${cardSurfaceFlat} shadow-2xl
+                 w-[95vw] h-[95dvh] max-w-6xl
+                 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+                 flex flex-col
+                 md:w-[90vw] md:h-[90dvh]`}
+          style={{ "z-index": baseZIndex }}
+        >
+          <div class={`flex items-start justify-between gap-4 px-6 py-3 border-b ${borderColor} flex-shrink-0`}>
+            <div class="min-w-0 space-y-1">
+              <Dialog.Label class="text-lg font-semibold text-heading break-all">{title()}</Dialog.Label>
+              <Show when={props.file?.path}>
+                <div class="font-mono text-xs text-text-muted break-all">{props.file?.path}</div>
+              </Show>
+            </div>
+
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <Show when={props.file?.isMarkdown}>
+                <div class="flex items-center rounded-lg border border-border overflow-hidden bg-surface">
+                  <button
+                    type="button"
+                    class="px-3 py-1.5 text-sm font-medium transition-colors"
+                    classList={{
+                      "bg-accent text-text-on-accent": markdownMode() === "rich",
+                      "text-text-muted hover:text-text-primary": markdownMode() !== "rich",
+                    }}
+                    aria-pressed={markdownMode() === "rich"}
+                    onClick={() => setMarkdownMode("rich")}
+                  >
+                    Rich
+                  </button>
+                  <button
+                    type="button"
+                    class="px-3 py-1.5 text-sm font-medium transition-colors"
+                    classList={{
+                      "bg-accent text-text-on-accent": markdownMode() === "raw",
+                      "text-text-muted hover:text-text-primary": markdownMode() !== "raw",
+                    }}
+                    aria-pressed={markdownMode() === "raw"}
+                    onClick={() => setMarkdownMode("raw")}
+                  >
+                    Raw
+                  </button>
+                </div>
+              </Show>
+              <Show when={props.file?.content}>
+                <CopyButton text={props.file?.content ?? ""} />
+              </Show>
+              <Dialog.Close class="text-text-muted hover:text-text-primary transition-colors focus:outline-none rounded p-1 w-8 h-8 flex items-center justify-center flex-shrink-0">
+                <span class="text-xl leading-none select-none">×</span>
+              </Dialog.Close>
+            </div>
+          </div>
+
+          <div class="flex-1 overflow-auto p-6 rounded-b-2xl">
+            <Show when={!props.loading} fallback={<div class="text-text-muted text-center py-12">Loading file...</div>}>
+              <Show when={!props.error} fallback={<div class="text-danger text-center py-12">{props.error}</div>}>
+                <Show
+                  when={props.file?.content?.trim().length}
+                  fallback={<div class="text-text-muted text-center py-12">No content to display</div>}
+                >
+                  <Show
+                    when={props.file?.isMarkdown && markdownMode() === "rich"}
+                    fallback={
+                      <Suspense
+                        fallback={
+                          <div class={`rounded ${cardSurface} overflow-hidden`}>
+                            <div class="h-24 bg-surface-raised animate-pulse" />
+                          </div>
+                        }
+                      >
+                        <CodeBlockContainer
+                          code={props.file?.content ?? ""}
+                          language={props.file?.language || "text"}
+                          theme={resolvedTheme()}
+                          showCopyButton={true}
+                        />
+                      </Suspense>
+                    }
+                  >
+                    <div class="rounded-xl border border-border-muted/70 bg-surface-overlay/40 p-6">
+                      <MarkdownRenderer
+                        content={props.file?.content ?? ""}
+                        {...(props.workspaceId ? { workspaceId: props.workspaceId } : {})}
+                      />
+                    </div>
+                  </Show>
+                </Show>
+              </Show>
+            </Show>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  );
+};
+
+export default FileViewerDialog;

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -59,6 +59,7 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
   };
 
   const title = createMemo(() => props.file?.name ?? "File Viewer");
+  const isRichMarkdown = createMemo(() => props.file?.isMarkdown && markdownMode() === "rich");
 
   return (
     <Dialog
@@ -134,9 +135,14 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
             </div>
           </div>
 
-          <div class="flex-1 overflow-auto p-6 rounded-b-2xl">
+          <div
+            class="flex-1 overflow-auto rounded-b-2xl"
+            classList={{
+              "p-6": !!isRichMarkdown(),
+            }}
+          >
             <Show when={revealError()}>
-              <div class="mb-4 rounded-lg border border-danger bg-danger/10 p-3 text-sm text-danger">
+              <div class="m-6 rounded-lg border border-danger bg-danger/10 p-3 text-sm text-danger">
                 {revealError()}
               </div>
             </Show>
@@ -149,7 +155,7 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
                   <Show
                     when={props.file?.isMarkdown && markdownMode() === "rich"}
                     fallback={
-                      <div class="h-full overflow-hidden rounded-xl">
+                      <div class="h-full overflow-hidden">
                         <TextEditor
                           value={props.file?.content ?? ""}
                           onInput={() => {}}
@@ -157,6 +163,7 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
                           disabled={true}
                           chrome={false}
                           height="100%"
+                          class="h-full"
                           ariaLabel={`${title()} raw file content`}
                           options={{ wordWrap: "off" }}
                         />

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -2,14 +2,17 @@
 // ABOUTME: Uses the shared markdown and code block renderers so file previews match the current app theme.
 
 import Dialog from "corvu/dialog";
+import { FolderOpen } from "lucide-solid";
 import { type Component, createEffect, createMemo, createSignal, Show, Suspense } from "solid-js";
 import { MarkdownRenderer } from "../../components/MarkdownRenderer";
 import CodeBlockContainer from "../../components/ui/CodeBlockContainer";
 import CopyButton from "../../components/ui/CopyButton";
+import IconButton from "../../components/ui/IconButton";
 import { useZIndex } from "../../contexts/ZIndexContext";
 import { borderColor, cardSurface, cardSurfaceFlat } from "../../styles/containerStyles";
 import { codeTheme, isDark } from "../../theme";
 import { resolveCodeTheme } from "../../theme/codeThemes";
+import { revealFileViewerPath } from "../services/file-viewer-api";
 import type { FileViewerFile } from "../types";
 
 type MarkdownViewMode = "rich" | "raw";
@@ -27,11 +30,25 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
   const baseZIndex = useZIndex();
   const resolvedTheme = createMemo(() => resolveCodeTheme(codeTheme(), isDark()));
   const [markdownMode, setMarkdownMode] = createSignal<MarkdownViewMode>("rich");
+  const [isRevealing, setIsRevealing] = createSignal(false);
 
   createEffect(() => {
     const file = props.file;
     setMarkdownMode(file?.isMarkdown ? "rich" : "raw");
   });
+
+  const handleReveal = async () => {
+    if (!props.workspaceId || !props.file?.path || isRevealing()) {
+      return;
+    }
+
+    setIsRevealing(true);
+    try {
+      await revealFileViewerPath(props.workspaceId, props.file.path);
+    } finally {
+      setIsRevealing(false);
+    }
+  };
 
   const title = createMemo(() => props.file?.name ?? "File Viewer");
 
@@ -92,6 +109,16 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
               </Show>
               <Show when={props.file?.content}>
                 <CopyButton text={props.file?.content ?? ""} />
+              </Show>
+              <Show when={props.workspaceId && props.file?.path}>
+                <IconButton
+                  icon={<FolderOpen size={16} />}
+                  variant="ghost"
+                  fixedSize={true}
+                  disabled={isRevealing()}
+                  aria-label="Reveal file in Finder"
+                  onClick={() => void handleReveal()}
+                />
               </Show>
               <Dialog.Close class="text-text-muted hover:text-text-primary transition-colors focus:outline-none rounded p-1 w-8 h-8 flex items-center justify-center flex-shrink-0">
                 <span class="text-xl leading-none select-none">×</span>

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -155,6 +155,7 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
                           onInput={() => {}}
                           language={props.file?.language || "text"}
                           disabled={true}
+                          chrome={false}
                           height="100%"
                           ariaLabel={`${title()} raw file content`}
                           options={{ wordWrap: "off" }}

--- a/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
+++ b/projects/birdhouse/frontend/src/file-viewer/components/FileViewerDialog.tsx
@@ -126,6 +126,7 @@ const FileViewerDialog: Component<FileViewerDialogProps> = (props) => {
                   fixedSize={true}
                   disabled={isRevealing()}
                   aria-label="Reveal file in Finder"
+                  title="Reveal file in Finder"
                   onClick={() => void handleReveal()}
                 />
               </Show>

--- a/projects/birdhouse/frontend/src/file-viewer/services/file-viewer-api.ts
+++ b/projects/birdhouse/frontend/src/file-viewer/services/file-viewer-api.ts
@@ -1,0 +1,32 @@
+// ABOUTME: API client for loading file contents into the generic file viewer.
+// ABOUTME: Keeps the backend contract stable while adapting snake_case fields into frontend types.
+
+import { API_ENDPOINT_BASE } from "../../config/api";
+import type { FileViewerFile } from "../types";
+
+interface FileViewerResponse {
+  path: string;
+  name: string;
+  content: string;
+  language: string;
+  is_markdown: boolean;
+}
+
+export async function fetchFileViewerContent(workspaceId: string, path: string): Promise<FileViewerFile> {
+  const url = `${API_ENDPOINT_BASE}/workspace/${encodeURIComponent(workspaceId)}/files/view?path=${encodeURIComponent(path)}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to load file: ${response.statusText} - ${text}`);
+  }
+
+  const data = (await response.json()) as FileViewerResponse;
+  return {
+    path: data.path,
+    name: data.name,
+    content: data.content,
+    language: data.language,
+    isMarkdown: data.is_markdown,
+  };
+}

--- a/projects/birdhouse/frontend/src/file-viewer/services/file-viewer-api.ts
+++ b/projects/birdhouse/frontend/src/file-viewer/services/file-viewer-api.ts
@@ -30,3 +30,17 @@ export async function fetchFileViewerContent(workspaceId: string, path: string):
     isMarkdown: data.is_markdown,
   };
 }
+
+export async function revealFileViewerPath(workspaceId: string, path: string): Promise<void> {
+  const url = `${API_ENDPOINT_BASE}/workspace/${encodeURIComponent(workspaceId)}/files/reveal`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ path }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to reveal file: ${response.statusText} - ${text}`);
+  }
+}

--- a/projects/birdhouse/frontend/src/file-viewer/types.ts
+++ b/projects/birdhouse/frontend/src/file-viewer/types.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Shared types for the generic read-only file viewer feature.
+// ABOUTME: Defines the payload returned from the server and rendered in the viewer dialog.
+
+export interface FileViewerFile {
+  path: string;
+  name: string;
+  content: string;
+  language: string;
+  isMarkdown: boolean;
+}

--- a/projects/birdhouse/frontend/src/file-viewer/utils/paths.ts
+++ b/projects/birdhouse/frontend/src/file-viewer/utils/paths.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Path helpers for file viewer consumers that need an absolute file path.
+// ABOUTME: Resolves a sibling file path from a known file location and a relative child path.
+
+export function resolveSiblingFilePath(baseFilePath: string, relativeFilePath: string): string {
+  const lastSlashIndex = Math.max(baseFilePath.lastIndexOf("/"), baseFilePath.lastIndexOf("\\"));
+  const separator = baseFilePath.includes("\\") ? "\\" : "/";
+  const baseDirectory = lastSlashIndex >= 0 ? baseFilePath.slice(0, lastSlashIndex) : baseFilePath;
+  const normalizedRelativePath = separator === "\\" ? relativeFilePath.replaceAll("/", "\\") : relativeFilePath;
+  return `${baseDirectory}${separator}${normalizedRelativePath}`;
+}

--- a/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.test.tsx
@@ -1,0 +1,118 @@
+// ABOUTME: Tests the shared skill detail content used by the library detail pane.
+// ABOUTME: Verifies the detail scroll container resets only when the selected skill changes.
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SkillDetail } from "../types/skill-library-types";
+import SkillDetailContent from "./SkillDetailContent";
+
+vi.mock("../../components/MarkdownRenderer", () => ({
+  default: (props: { content: string }) => <div>{props.content}</div>,
+}));
+
+vi.mock("../../components/ui/CodeBlock", () => ({
+  CodeBlock: (props: { code: string }) => <pre>{props.code}</pre>,
+}));
+
+vi.mock("../../components/ui/IconButton", () => ({
+  default: (props: { "aria-label": string; onClick?: () => void }) => (
+    <button type="button" aria-label={props["aria-label"]} onClick={props.onClick} />
+  ),
+}));
+
+vi.mock("../../file-viewer/components/FileViewerDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../file-viewer/services/file-viewer-api", () => ({
+  fetchFileViewerContent: vi.fn(),
+}));
+
+vi.mock("../../theme", () => ({
+  resolvedCodeTheme: () => "github-dark",
+}));
+
+vi.mock("../services/skill-library-api", () => ({
+  revealSkillLocation: vi.fn(),
+}));
+
+vi.mock("./SkillTagList", () => ({
+  default: (props: { tags: string[] }) => <div>{props.tags.join(", ")}</div>,
+}));
+
+vi.mock("./TriggerPhraseEditor", () => ({
+  default: () => <div>Trigger Phrase Editor</div>,
+}));
+
+const baseSkill: SkillDetail = {
+  id: "find-docs",
+  title: "find-docs",
+  description: "Retrieve current library docs.",
+  tags: ["docs", "research"],
+  metadata: {
+    description: "Retrieve current library docs.",
+    license: "MIT",
+  },
+  prompt: "# Find Docs\n\nUse Context7 first.",
+  trigger_phrases: ["docs please"],
+  metadata_trigger_phrases: [],
+  files: [],
+  readonly: true,
+  scope: "global",
+  location: "/Users/test/.claude/skills/find-docs/SKILL.md",
+  display_location: "~/.claude/skills/find-docs/SKILL.md",
+};
+
+describe("SkillDetailContent", () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollTo = vi.fn();
+  });
+
+  it("resets the detail scroll position when switching to a different skill", async () => {
+    const otherSkill: SkillDetail = {
+      ...baseSkill,
+      id: "release-notes-from-branch",
+      title: "release-notes-from-branch",
+      description: "Generate release notes from git history.",
+      metadata: {
+        description: "Generate release notes from git history.",
+        license: "Apache-2.0",
+      },
+      prompt: "# Release Notes\n\nSummarize the branch.",
+      trigger_phrases: ["generate release notes"],
+      location: "/repo/.agents/skills/release-notes/SKILL.md",
+      display_location: "/repo/.agents/skills/release-notes/SKILL.md",
+    };
+
+    const Wrapper = () => {
+      const [skill, setSkill] = createSignal(baseSkill);
+
+      return (
+        <>
+          <button type="button" onClick={() => setSkill(otherSkill)}>
+            Select release notes
+          </button>
+          <button type="button" onClick={() => setSkill({ ...baseSkill })}>
+            Refetch same skill
+          </button>
+          <SkillDetailContent
+            skill={skill()}
+            workspaceId="ws_test"
+            onUpdateTriggerPhrases={vi.fn().mockResolvedValue(undefined)}
+          />
+        </>
+      );
+    };
+
+    render(() => <Wrapper />);
+
+    const scrollToMock = vi.mocked(HTMLElement.prototype.scrollTo);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refetch same skill" }));
+    expect(scrollToMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select release notes" }));
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 0 });
+  });
+});

--- a/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.test.tsx
@@ -1,11 +1,15 @@
 // ABOUTME: Tests the shared skill detail content used by the library detail pane.
 // ABOUTME: Verifies the detail scroll container resets only when the selected skill changes.
 
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillDetail } from "../types/skill-library-types";
 import SkillDetailContent from "./SkillDetailContent";
+
+const { fetchFileViewerContentMock } = vi.hoisted(() => ({
+  fetchFileViewerContentMock: vi.fn(),
+}));
 
 vi.mock("../../components/MarkdownRenderer", () => ({
   default: (props: { content: string }) => <div>{props.content}</div>,
@@ -22,11 +26,24 @@ vi.mock("../../components/ui/IconButton", () => ({
 }));
 
 vi.mock("../../file-viewer/components/FileViewerDialog", () => ({
-  default: () => null,
+  default: (props: {
+    open: boolean;
+    loading?: boolean;
+    error?: string | null;
+    file: { name: string; path: string } | null;
+  }) => (
+    <div data-testid="file-viewer">
+      <div>{props.open ? "viewer-open" : "viewer-closed"}</div>
+      <div>{props.loading ? "viewer-loading" : "viewer-idle"}</div>
+      <div>{props.error ?? "viewer-no-error"}</div>
+      <div>{props.file?.name ?? "viewer-no-file"}</div>
+      <div>{props.file?.path ?? "viewer-no-path"}</div>
+    </div>
+  ),
 }));
 
 vi.mock("../../file-viewer/services/file-viewer-api", () => ({
-  fetchFileViewerContent: vi.fn(),
+  fetchFileViewerContent: (workspaceId: string, path: string) => fetchFileViewerContentMock(workspaceId, path),
 }));
 
 vi.mock("../../theme", () => ({
@@ -64,9 +81,20 @@ const baseSkill: SkillDetail = {
   display_location: "~/.claude/skills/find-docs/SKILL.md",
 };
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("SkillDetailContent", () => {
   beforeEach(() => {
     HTMLElement.prototype.scrollTo = vi.fn();
+    fetchFileViewerContentMock.mockReset();
   });
 
   it("resets the detail scroll position when switching to a different skill", async () => {
@@ -114,5 +142,122 @@ describe("SkillDetailContent", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select release notes" }));
     expect(scrollToMock).toHaveBeenCalledWith({ top: 0 });
+  });
+
+  it("resets the supporting file viewer when switching to a different skill", async () => {
+    const skillWithFile: SkillDetail = {
+      ...baseSkill,
+      files: ["examples/basic.md"],
+    };
+    const otherSkill: SkillDetail = {
+      ...baseSkill,
+      id: "release-notes-from-branch",
+      title: "release-notes-from-branch",
+      files: [],
+      location: "/repo/.agents/skills/release-notes/SKILL.md",
+      display_location: "/repo/.agents/skills/release-notes/SKILL.md",
+    };
+
+    fetchFileViewerContentMock.mockResolvedValueOnce({
+      path: "/Users/test/.claude/skills/find-docs/examples/basic.md",
+      name: "basic.md",
+      content: "# Example",
+      language: "markdown",
+      isMarkdown: true,
+    });
+
+    const Wrapper = () => {
+      const [skill, setSkill] = createSignal(skillWithFile);
+
+      return (
+        <>
+          <button type="button" onClick={() => setSkill(otherSkill)}>
+            Select release notes
+          </button>
+          <SkillDetailContent
+            skill={skill()}
+            workspaceId="ws_test"
+            onUpdateTriggerPhrases={vi.fn().mockResolvedValue(undefined)}
+          />
+        </>
+      );
+    };
+
+    render(() => <Wrapper />);
+
+    fireEvent.click(screen.getByRole("button", { name: "examples/basic.md" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("viewer-open");
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("basic.md");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Select release notes" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("viewer-closed");
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("viewer-no-file");
+    });
+  });
+
+  it("keeps the newest supporting file response when requests resolve out of order", async () => {
+    const skillWithFiles: SkillDetail = {
+      ...baseSkill,
+      files: ["examples/first.md", "examples/second.md"],
+    };
+    const firstRequest = createDeferred<{
+      path: string;
+      name: string;
+      content: string;
+      language: string;
+      isMarkdown: boolean;
+    }>();
+    const secondRequest = createDeferred<{
+      path: string;
+      name: string;
+      content: string;
+      language: string;
+      isMarkdown: boolean;
+    }>();
+
+    fetchFileViewerContentMock.mockReturnValueOnce(firstRequest.promise).mockReturnValueOnce(secondRequest.promise);
+
+    render(() => (
+      <SkillDetailContent
+        skill={skillWithFiles}
+        workspaceId="ws_test"
+        onUpdateTriggerPhrases={vi.fn().mockResolvedValue(undefined)}
+      />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "examples/first.md" }));
+    fireEvent.click(screen.getByRole("button", { name: "examples/second.md" }));
+
+    secondRequest.resolve({
+      path: "/Users/test/.claude/skills/find-docs/examples/second.md",
+      name: "second.md",
+      content: "# Second",
+      language: "markdown",
+      isMarkdown: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("viewer-open");
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("second.md");
+      expect(screen.getByTestId("file-viewer")).toHaveTextContent("viewer-idle");
+    });
+
+    firstRequest.resolve({
+      path: "/Users/test/.claude/skills/find-docs/examples/first.md",
+      name: "first.md",
+      content: "# First",
+      language: "markdown",
+      isMarkdown: true,
+    });
+
+    await Promise.resolve();
+
+    expect(screen.getByTestId("file-viewer")).toHaveTextContent("second.md");
+    expect(screen.getByTestId("file-viewer")).not.toHaveTextContent("first.md");
   });
 });

--- a/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Renders metadata, trigger phrases, supporting files, and XML preview for one selected skill.
 
 import { ChevronRight, FolderOpen } from "lucide-solid";
-import { type Component, createSignal, For, Show } from "solid-js";
+import { type Component, createEffect, createSignal, For, Show } from "solid-js";
 import MarkdownRenderer from "../../components/MarkdownRenderer";
 import { CodeBlock } from "../../components/ui/CodeBlock";
 import IconButton from "../../components/ui/IconButton";
@@ -115,6 +115,8 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
   const [viewerLoading, setViewerLoading] = createSignal(false);
   const [viewerError, setViewerError] = createSignal<string | null>(null);
   const [viewedFile, setViewedFile] = createSignal<import("../../file-viewer/types").FileViewerFile | null>(null);
+  let detailScrollRef: HTMLDivElement | undefined;
+  let previousSkillId = props.skill.id;
 
   const scopeTitle = () => "Trigger Phrases";
   const scopeDescription = () => "Choose the phrases that suggest this skill while you type.";
@@ -170,9 +172,26 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
     }
   };
 
+  createEffect(() => {
+    const skillId = props.skill.id;
+    if (skillId === previousSkillId) {
+      return;
+    }
+
+    previousSkillId = skillId;
+
+    if (detailScrollRef) {
+      if (typeof detailScrollRef.scrollTo === "function") {
+        detailScrollRef.scrollTo({ top: 0 });
+      } else {
+        detailScrollRef.scrollTop = 0;
+      }
+    }
+  });
+
   return (
     <>
-      <div class="flex-1 overflow-y-auto p-8 space-y-8">
+      <div ref={detailScrollRef} class="flex-1 overflow-y-auto p-8 space-y-8">
         <Show when={error()}>
           <div class="p-3 bg-danger/10 border border-danger rounded text-sm text-danger">{error()}</div>
         </Show>

--- a/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.tsx
@@ -6,6 +6,9 @@ import { type Component, createSignal, For, Show } from "solid-js";
 import MarkdownRenderer from "../../components/MarkdownRenderer";
 import { CodeBlock } from "../../components/ui/CodeBlock";
 import IconButton from "../../components/ui/IconButton";
+import FileViewerDialog from "../../file-viewer/components/FileViewerDialog";
+import { fetchFileViewerContent } from "../../file-viewer/services/file-viewer-api";
+import { resolveSiblingFilePath } from "../../file-viewer/utils/paths";
 import { cardSurfaceFlat } from "../../styles/containerStyles";
 import { resolvedCodeTheme } from "../../theme";
 import { revealSkillLocation } from "../services/skill-library-api";
@@ -108,6 +111,10 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
   const [isSaving, setIsSaving] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [isRevealing, setIsRevealing] = createSignal(false);
+  const [viewerOpen, setViewerOpen] = createSignal(false);
+  const [viewerLoading, setViewerLoading] = createSignal(false);
+  const [viewerError, setViewerError] = createSignal<string | null>(null);
+  const [viewedFile, setViewedFile] = createSignal<import("../../file-viewer/types").FileViewerFile | null>(null);
 
   const scopeTitle = () => "Trigger Phrases";
   const scopeDescription = () => "Choose the phrases that suggest this skill while you type.";
@@ -146,122 +153,156 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
     }
   };
 
+  const handleOpenSupportingFile = async (relativeFilePath: string) => {
+    const absoluteFilePath = resolveSiblingFilePath(props.skill.location, relativeFilePath);
+    setViewerOpen(true);
+    setViewerLoading(true);
+    setViewerError(null);
+
+    try {
+      const file = await fetchFileViewerContent(props.workspaceId, absoluteFilePath);
+      setViewedFile(file);
+    } catch (err) {
+      setViewedFile(null);
+      setViewerError(err instanceof Error ? err.message : "Failed to load file");
+    } finally {
+      setViewerLoading(false);
+    }
+  };
+
   return (
-    <div class="flex-1 overflow-y-auto p-8 space-y-8">
-      <Show when={error()}>
-        <div class="p-3 bg-danger/10 border border-danger rounded text-sm text-danger">{error()}</div>
-      </Show>
+    <>
+      <div class="flex-1 overflow-y-auto p-8 space-y-8">
+        <Show when={error()}>
+          <div class="p-3 bg-danger/10 border border-danger rounded text-sm text-danger">{error()}</div>
+        </Show>
 
-      <Show when={isSaving()}>
-        <div class="text-xs text-text-muted px-2">Saving changes...</div>
-      </Show>
+        <Show when={isSaving()}>
+          <div class="text-xs text-text-muted px-2">Saving changes...</div>
+        </Show>
 
-      <Show when={metadataEntries().length > 0 || props.skill.display_location}>
-        <DetailSection title="Details" defaultExpanded={true}>
-          <dl class="space-y-4">
-            <Show when={descriptionValue()}>
-              <div class="space-y-1">
-                <dt class="text-sm font-semibold text-heading">Description</dt>
-                <dd class="whitespace-pre-wrap break-words text-sm text-text-primary leading-relaxed">
-                  {isMultilineText(descriptionValue() ?? "") ? (
-                    <MarkdownRenderer content={descriptionValue() ?? ""} />
-                  ) : (
-                    descriptionValue()
-                  )}
-                </dd>
-              </div>
-            </Show>
-
-            <Show when={props.skill.tags.length > 0}>
-              <div class="space-y-1">
-                <dt class="text-sm font-semibold text-heading">Tags</dt>
-                <dd>
-                  <SkillTagList tags={props.skill.tags} />
-                </dd>
-              </div>
-            </Show>
-
-            <For each={metadataEntries()}>
-              {([key, value]) => (
+        <Show when={metadataEntries().length > 0 || props.skill.display_location}>
+          <DetailSection title="Details" defaultExpanded={true}>
+            <dl class="space-y-4">
+              <Show when={descriptionValue()}>
                 <div class="space-y-1">
-                  <dt class="text-sm font-semibold text-heading">{formatMetadataLabel(key)}</dt>
-                  <Show
-                    when={isStructuredMetadataValue(value)}
-                    fallback={
-                      <dd
-                        classList={{
-                          "whitespace-pre-wrap break-words text-sm text-text-primary leading-relaxed": true,
-                          "font-mono": typeof value !== "string",
-                        }}
-                      >
-                        {typeof value === "string" && isMultilineText(value) ? (
-                          <MarkdownRenderer content={value} />
-                        ) : (
-                          formatMetadataValue(value)
-                        )}
-                      </dd>
-                    }
-                  >
-                    <dd class="overflow-hidden rounded-lg border border-border-muted bg-surface-overlay/60">
-                      <CodeBlock code={formatMetadataValue(value)} language="json" theme={resolvedCodeTheme()} />
-                    </dd>
-                  </Show>
+                  <dt class="text-sm font-semibold text-heading">Description</dt>
+                  <dd class="whitespace-pre-wrap break-words text-sm text-text-primary leading-relaxed">
+                    {isMultilineText(descriptionValue() ?? "") ? (
+                      <MarkdownRenderer content={descriptionValue() ?? ""} />
+                    ) : (
+                      descriptionValue()
+                    )}
+                  </dd>
                 </div>
-              )}
-            </For>
+              </Show>
 
-            <div class="space-y-1 pt-2 border-t border-border-muted/60">
-              <dt class="text-sm font-semibold text-heading">Location</dt>
-              <dd class="flex items-center gap-2 text-sm text-text-primary">
-                <span class="font-mono break-all flex-1">{locationDisplay()}</span>
-                <IconButton
-                  icon={<FolderOpen size={16} />}
-                  variant="ghost"
-                  fixedSize={true}
-                  disabled={isRevealing()}
-                  aria-label="Reveal skill folder in Finder"
-                  onClick={() => void handleRevealLocation()}
-                />
-              </dd>
+              <Show when={props.skill.tags.length > 0}>
+                <div class="space-y-1">
+                  <dt class="text-sm font-semibold text-heading">Tags</dt>
+                  <dd>
+                    <SkillTagList tags={props.skill.tags} />
+                  </dd>
+                </div>
+              </Show>
+
+              <For each={metadataEntries()}>
+                {([key, value]) => (
+                  <div class="space-y-1">
+                    <dt class="text-sm font-semibold text-heading">{formatMetadataLabel(key)}</dt>
+                    <Show
+                      when={isStructuredMetadataValue(value)}
+                      fallback={
+                        <dd
+                          classList={{
+                            "whitespace-pre-wrap break-words text-sm text-text-primary leading-relaxed": true,
+                            "font-mono": typeof value !== "string",
+                          }}
+                        >
+                          {typeof value === "string" && isMultilineText(value) ? (
+                            <MarkdownRenderer content={value} />
+                          ) : (
+                            formatMetadataValue(value)
+                          )}
+                        </dd>
+                      }
+                    >
+                      <dd class="overflow-hidden rounded-lg border border-border-muted bg-surface-overlay/60">
+                        <CodeBlock code={formatMetadataValue(value)} language="json" theme={resolvedCodeTheme()} />
+                      </dd>
+                    </Show>
+                  </div>
+                )}
+              </For>
+
+              <div class="space-y-1 pt-2 border-t border-border-muted/60">
+                <dt class="text-sm font-semibold text-heading">Location</dt>
+                <dd class="flex items-center gap-2 text-sm text-text-primary">
+                  <span class="font-mono break-all flex-1">{locationDisplay()}</span>
+                  <IconButton
+                    icon={<FolderOpen size={16} />}
+                    variant="ghost"
+                    fixedSize={true}
+                    disabled={isRevealing()}
+                    aria-label="Reveal skill folder in Finder"
+                    onClick={() => void handleRevealLocation()}
+                  />
+                </dd>
+              </div>
+            </dl>
+          </DetailSection>
+        </Show>
+
+        <DetailSection title={scopeTitle()} description={scopeDescription()} defaultExpanded={true}>
+          <TriggerPhraseEditor
+            phrases={props.skill.trigger_phrases}
+            readonlyPhrases={props.skill.metadata_trigger_phrases}
+            onSave={handleSaveTriggerPhrases}
+          />
+        </DetailSection>
+
+        <Show when={props.skill.files.length > 0}>
+          <DetailSection
+            title="Supporting Files"
+            description="Additional files found alongside SKILL.md."
+            defaultExpanded={true}
+          >
+            <ul class="space-y-2">
+              <For each={props.skill.files}>
+                {(file) => (
+                  <li>
+                    <button
+                      type="button"
+                      class="w-full rounded-lg border border-border-muted/70 bg-surface-overlay/60 px-3 py-2 text-left font-mono text-sm text-text-primary break-all transition-colors hover:bg-surface-overlay hover:border-border"
+                      onClick={() => void handleOpenSupportingFile(file)}
+                    >
+                      {file}
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </DetailSection>
+        </Show>
+
+        <DetailSection title="SKILL.md Content" defaultExpanded={true}>
+          <div class={`rounded-xl ${cardSurfaceFlat} overflow-hidden`}>
+            <div class="p-6">
+              <MarkdownRenderer content={props.skill.prompt} />
             </div>
-          </dl>
-        </DetailSection>
-      </Show>
-
-      <DetailSection title={scopeTitle()} description={scopeDescription()} defaultExpanded={true}>
-        <TriggerPhraseEditor
-          phrases={props.skill.trigger_phrases}
-          readonlyPhrases={props.skill.metadata_trigger_phrases}
-          onSave={handleSaveTriggerPhrases}
-        />
-      </DetailSection>
-
-      <Show when={props.skill.files.length > 0}>
-        <DetailSection
-          title="Supporting Files"
-          description="Additional files found alongside SKILL.md."
-          defaultExpanded={true}
-        >
-          <ul class="space-y-2">
-            <For each={props.skill.files}>
-              {(file) => (
-                <li class="rounded-lg border border-border-muted/70 bg-surface-overlay/60 px-3 py-2 font-mono text-sm text-text-primary break-all">
-                  {file}
-                </li>
-              )}
-            </For>
-          </ul>
-        </DetailSection>
-      </Show>
-
-      <DetailSection title="SKILL.md Content" defaultExpanded={true}>
-        <div class={`rounded-xl ${cardSurfaceFlat} overflow-hidden`}>
-          <div class="p-6">
-            <MarkdownRenderer content={props.skill.prompt} />
           </div>
-        </div>
-      </DetailSection>
-    </div>
+        </DetailSection>
+      </div>
+
+      <FileViewerDialog
+        open={viewerOpen()}
+        onOpenChange={setViewerOpen}
+        file={viewedFile()}
+        workspaceId={props.workspaceId}
+        loading={viewerLoading()}
+        error={viewerError()}
+      />
+    </>
   );
 };
 

--- a/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillDetailContent.tsx
@@ -117,6 +117,7 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
   const [viewedFile, setViewedFile] = createSignal<import("../../file-viewer/types").FileViewerFile | null>(null);
   let detailScrollRef: HTMLDivElement | undefined;
   let previousSkillId = props.skill.id;
+  let supportingFileRequestId = 0;
 
   const scopeTitle = () => "Trigger Phrases";
   const scopeDescription = () => "Choose the phrases that suggest this skill while you type.";
@@ -127,6 +128,12 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
   const metadataEntries = () =>
     Object.entries(props.skill.metadata).filter(([key]) => !["name", "description", "tags"].includes(key));
   const locationDisplay = () => props.skill.display_location;
+  const resetViewerState = () => {
+    setViewerOpen(false);
+    setViewerLoading(false);
+    setViewerError(null);
+    setViewedFile(null);
+  };
 
   const handleSaveTriggerPhrases = async (phrases: string[]) => {
     setIsSaving(true);
@@ -156,19 +163,31 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
   };
 
   const handleOpenSupportingFile = async (relativeFilePath: string) => {
+    const requestId = ++supportingFileRequestId;
     const absoluteFilePath = resolveSiblingFilePath(props.skill.location, relativeFilePath);
     setViewerOpen(true);
     setViewerLoading(true);
     setViewerError(null);
+    setViewedFile(null);
 
     try {
       const file = await fetchFileViewerContent(props.workspaceId, absoluteFilePath);
+      if (requestId !== supportingFileRequestId) {
+        return;
+      }
+
       setViewedFile(file);
     } catch (err) {
+      if (requestId !== supportingFileRequestId) {
+        return;
+      }
+
       setViewedFile(null);
       setViewerError(err instanceof Error ? err.message : "Failed to load file");
     } finally {
-      setViewerLoading(false);
+      if (requestId === supportingFileRequestId) {
+        setViewerLoading(false);
+      }
     }
   };
 
@@ -179,6 +198,8 @@ const SkillDetailContent: Component<SkillDetailContentProps> = (props) => {
     }
 
     previousSkillId = skillId;
+    supportingFileRequestId += 1;
+    resetViewerState();
 
     if (detailScrollRef) {
       if (typeof detailScrollRef.scrollTo === "function") {

--- a/projects/birdhouse/frontend/src/skills/components/SkillDetailModal.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillDetailModal.test.tsx
@@ -5,6 +5,22 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
 import SkillDetailModal from "./SkillDetailModal";
 
+const { fetchFileViewerContentMock } = vi.hoisted(() => ({
+  fetchFileViewerContentMock: vi.fn(),
+}));
+
+vi.mock("../../contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({ workspaceId: "ws_test" }),
+}));
+
+vi.mock("../../contexts/ZIndexContext", () => ({
+  useZIndex: () => 100,
+}));
+
+vi.mock("../../file-viewer/services/file-viewer-api", () => ({
+  fetchFileViewerContent: (workspaceId: string, path: string) => fetchFileViewerContentMock(workspaceId, path),
+}));
+
 describe("SkillDetailModal", () => {
   const baseSkill = {
     id: "find-docs",
@@ -28,7 +44,7 @@ describe("SkillDetailModal", () => {
     files: ["examples/basic.md", "templates/query.txt"],
   };
 
-  it("renders supporting files as an expanded list by default", async () => {
+  it("renders supporting files as interactive controls by default", async () => {
     render(() => (
       <SkillDetailModal
         open={true}
@@ -56,10 +72,10 @@ describe("SkillDetailModal", () => {
     expect(screen.getByText("Additional files found alongside SKILL.md.")).toBeInTheDocument();
 
     const fileList = screen.getByRole("list");
-    const fileItems = screen.getAllByRole("listitem");
+    const fileButtons = screen.getAllByRole("button", { name: /examples\/basic\.md|templates\/query\.txt/ });
 
     expect(fileList).toBeInTheDocument();
-    expect(fileItems).toHaveLength(2);
+    expect(fileButtons).toHaveLength(2);
     expect(screen.getByText("examples/basic.md")).toBeInTheDocument();
     expect(screen.getByText("templates/query.txt")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Find Docs" })).toBeInTheDocument();
@@ -93,5 +109,38 @@ describe("SkillDetailModal", () => {
       expect(onUpdateTriggerPhrases).toHaveBeenCalledWith(["docs please", "reference the docs"]);
     });
     expect(screen.getByText("Trigger Phrases")).toBeInTheDocument();
+  });
+
+  it("opens the generic file viewer when a supporting file is clicked", async () => {
+    fetchFileViewerContentMock.mockResolvedValueOnce({
+      path: "/Users/test/.claude/skills/find-docs/examples/basic.md",
+      name: "basic.md",
+      content: "# Example\n\nSkill example content.",
+      language: "markdown",
+      isMarkdown: true,
+    });
+
+    render(() => (
+      <SkillDetailModal
+        open={true}
+        onOpenChange={() => {}}
+        skill={baseSkill}
+        workspaceId="ws_test"
+        onUpdateTriggerPhrases={vi.fn().mockResolvedValue(undefined)}
+      />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "examples/basic.md" }));
+
+    await waitFor(() => {
+      expect(fetchFileViewerContentMock).toHaveBeenCalledWith(
+        "ws_test",
+        "/Users/test/.claude/skills/find-docs/examples/basic.md",
+      );
+    });
+
+    expect(screen.getByRole("dialog", { name: "basic.md" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rich" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("heading", { name: "Example" })).toBeInTheDocument();
   });
 });

--- a/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
@@ -77,8 +77,10 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
   const [searchQuery, setSearchQuery] = createSignal("");
   const [scopeFilter, setScopeFilter] = createSignal<SkillListScopeFilter>("all");
   const [storedSelectedSkillId, setStoredSelectedSkillId] = createSignal<string | null>(null);
+  const [autoScrollSkillId, setAutoScrollSkillId] = createSignal<string | null>(null);
   const [reloadingSkills, setReloadingSkills] = createSignal(false);
   const [reloadError, setReloadError] = createSignal<string | null>(null);
+  let wasLibraryOpen = false;
 
   const isLibraryOpen = createMemo(() => modalStack().some((modal) => modal.type === MODAL_TYPE_LIBRARY));
 
@@ -126,6 +128,17 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
   });
 
   createEffect(() => {
+    const open = isLibraryOpen();
+    if (open && !wasLibraryOpen) {
+      setAutoScrollSkillId(selectedSkillId());
+    } else if (!open && wasLibraryOpen) {
+      setAutoScrollSkillId(null);
+    }
+
+    wasLibraryOpen = open;
+  });
+
+  createEffect(() => {
     const currentSelectedSkillId = selectedSkillId();
     if (currentSelectedSkillId) {
       setStoredSelectedSkillId(currentSelectedSkillId);
@@ -140,11 +153,12 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
     });
   });
 
-  const selectSkill = (skillId: string | null) => {
+  const selectSkill = (skillId: string | null, options?: { autoScroll?: boolean }) => {
     const nextId = skillId || "main";
     if (skillId) {
       setStoredSelectedSkillId(skillId);
     }
+    setAutoScrollSkillId(options?.autoScroll && skillId ? skillId : null);
     replaceModal(MODAL_TYPE_LIBRARY, nextId);
 
     if (!isDesktop()) {
@@ -205,7 +219,7 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
         );
 
         if (currentSelectedSkillId !== nextSelectedSkillId) {
-          selectSkill(nextSelectedSkillId);
+          selectSkill(nextSelectedSkillId, { autoScroll: !!nextSelectedSkillId });
         }
       },
     ),
@@ -218,9 +232,15 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
       searchQuery={searchQuery()}
       scopeFilter={scopeFilter()}
       selectedSkillId={selectedSkillId()}
+      autoScrollSkillId={autoScrollSkillId()}
       onSearchQueryChange={setSearchQuery}
       onScopeFilterChange={setScopeFilter}
       onSelectSkill={selectSkill}
+      onAutoScrollHandled={(skillId) => {
+        if (autoScrollSkillId() === skillId) {
+          setAutoScrollSkillId(null);
+        }
+      }}
     />
   );
 

--- a/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
@@ -7,6 +7,7 @@ import { Menu, RefreshCw, X } from "lucide-solid";
 import { type Component, createEffect, createMemo, createResource, createSignal, on, Show } from "solid-js";
 import MobileNavDrawer from "../../components/MobileNavDrawer";
 import { Button } from "../../components/ui";
+import { useZIndex, ZIndexProvider } from "../../contexts/ZIndexContext";
 import { useModalRoute } from "../../lib/routing";
 import { cardSurfaceFlat } from "../../styles/containerStyles";
 import { createMediaQuery } from "../../theme/createMediaQuery";
@@ -68,6 +69,8 @@ export interface SkillLibraryDialogProps {
 }
 
 const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
+  const inheritedZIndex = useZIndex();
+  const baseZIndex = inheritedZIndex + 50;
   const { closeModal, modalStack, replaceModal } = useModalRoute();
   const isDesktop = createMediaQuery("(min-width: 768px)");
   const [sidebarOpen, setSidebarOpen] = createSignal(true);
@@ -254,116 +257,119 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
       restoreScrollPosition={false}
     >
       <Dialog.Portal>
-        <Dialog.Overlay class="fixed inset-0 bg-black/60 backdrop-blur-sm z-[100]" />
+        <Dialog.Overlay class="fixed inset-0 bg-black/60 backdrop-blur-sm" style={{ "z-index": baseZIndex }} />
         <Dialog.Content
           class={`fixed rounded-2xl ${cardSurfaceFlat} shadow-2xl
                    w-[95vw] h-[95dvh] max-w-[1600px]
                    left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                   flex flex-col overflow-hidden z-[100]`}
+                   flex flex-col overflow-hidden`}
+          style={{ "z-index": baseZIndex + 2 }}
         >
-          <div class="flex items-center justify-between px-6 py-3 border-b border-border flex-shrink-0">
-            <div class="flex items-center gap-3">
-              <Show when={!isDesktop()}>
-                <button
-                  type="button"
-                  onClick={() => setSidebarOpen(!sidebarOpen())}
-                  class="flex items-center justify-center p-2 rounded-lg transition-all hover:bg-surface-overlay"
-                  classList={{
-                    "text-accent": sidebarOpen(),
-                    "text-text-secondary": !sidebarOpen(),
-                  }}
-                  aria-label="Toggle skills library"
-                >
-                  <Menu size={20} />
-                </button>
-              </Show>
-              <Dialog.Label class="text-lg font-semibold text-heading">Skills Library</Dialog.Label>
-            </div>
-
-            <div class="flex items-center gap-3">
-              <Show when={reloadError()}>
-                {(message) => <span class="hidden md:inline text-sm text-danger">{message()}</span>}
-              </Show>
-
-              <Button
-                variant="secondary"
-                onClick={handleReloadSkills}
-                disabled={reloadingSkills()}
-                leftIcon={<RefreshCw size={16} classList={{ "animate-spin": reloadingSkills() }} />}
-                class="whitespace-nowrap"
-                aria-label="Reload Skills"
-              >
-                {reloadingSkills() ? "Reloading..." : "Reload Skills"}
-              </Button>
-
-              <Dialog.Close class="text-text-muted hover:text-text-primary transition-colors">
-                <X size={20} />
-              </Dialog.Close>
-            </div>
-          </div>
-
-          <div class="flex-1 overflow-hidden p-2 bg-gradient-to-br from-bg-from via-bg-via to-bg-to">
-            <Show
-              when={isDesktop()}
-              fallback={
-                <>
-                  <MobileNavDrawer
-                    components={[]}
-                    selectedComponent=""
-                    onSelect={() => {}}
-                    open={sidebarOpen()}
-                    onOpenChange={setSidebarOpen}
-                    trigger={null}
-                    zIndex={110}
+          <ZIndexProvider baseZIndex={baseZIndex + 10}>
+            <div class="flex items-center justify-between px-6 py-3 border-b border-border flex-shrink-0">
+              <div class="flex items-center gap-3">
+                <Show when={!isDesktop()}>
+                  <button
+                    type="button"
+                    onClick={() => setSidebarOpen(!sidebarOpen())}
+                    class="flex items-center justify-center p-2 rounded-lg transition-all hover:bg-surface-overlay"
+                    classList={{
+                      "text-accent": sidebarOpen(),
+                      "text-text-secondary": !sidebarOpen(),
+                    }}
+                    aria-label="Toggle skills library"
                   >
-                    <div class="h-full bg-surface-raised overflow-hidden flex flex-col">{listPaneContent()}</div>
-                  </MobileNavDrawer>
+                    <Menu size={20} />
+                  </button>
+                </Show>
+                <Dialog.Label class="text-lg font-semibold text-heading">Skills Library</Dialog.Label>
+              </div>
 
-                  <SkillDetailPane
-                    skill={visibleSkill()}
-                    loading={skillData.loading}
-                    error={skillData.error ?? null}
-                    workspaceId={props.workspaceId}
-                    onRetry={() => refetchSkill()}
-                    onUpdateTriggerPhrases={handleUpdateTriggerPhrases}
-                  />
-                </>
-              }
-            >
-              <Resizable class="h-full" orientation="horizontal">
-                {() => (
+              <div class="flex items-center gap-3">
+                <Show when={reloadError()}>
+                  {(message) => <span class="hidden md:inline text-sm text-danger">{message()}</span>}
+                </Show>
+
+                <Button
+                  variant="secondary"
+                  onClick={handleReloadSkills}
+                  disabled={reloadingSkills()}
+                  leftIcon={<RefreshCw size={16} classList={{ "animate-spin": reloadingSkills() }} />}
+                  class="whitespace-nowrap"
+                  aria-label="Reload Skills"
+                >
+                  {reloadingSkills() ? "Reloading..." : "Reload Skills"}
+                </Button>
+
+                <Dialog.Close class="text-text-muted hover:text-text-primary transition-colors">
+                  <X size={20} />
+                </Dialog.Close>
+              </div>
+            </div>
+
+            <div class="flex-1 overflow-hidden p-2 bg-gradient-to-br from-bg-from via-bg-via to-bg-to">
+              <Show
+                when={isDesktop()}
+                fallback={
                   <>
-                    <Resizable.Panel
-                      initialSize={0.382}
-                      minSize={0.25}
-                      maxSize={0.5}
-                      class="h-full bg-surface-raised rounded-lg overflow-hidden flex flex-col"
+                    <MobileNavDrawer
+                      components={[]}
+                      selectedComponent=""
+                      onSelect={() => {}}
+                      open={sidebarOpen()}
+                      onOpenChange={setSidebarOpen}
+                      trigger={null}
+                      zIndex={baseZIndex + 20}
                     >
-                      {listPaneContent()}
-                    </Resizable.Panel>
+                      <div class="h-full bg-surface-raised overflow-hidden flex flex-col">{listPaneContent()}</div>
+                    </MobileNavDrawer>
 
-                    <Resizable.Handle
-                      aria-label="Resize skill list panel"
-                      class="w-4 cursor-col-resize flex items-center justify-center group"
-                    >
-                      <div class="w-1 h-full bg-accent opacity-0 group-hover:opacity-100 transition-opacity" />
-                    </Resizable.Handle>
-
-                    <Resizable.Panel initialSize={0.618} minSize={0.5} class="h-full rounded-lg overflow-hidden">
-                      <SkillDetailPane
-                        skill={visibleSkill()}
-                        loading={skillData.loading}
-                        error={skillData.error ?? null}
-                        workspaceId={props.workspaceId}
-                        onRetry={() => refetchSkill()}
-                        onUpdateTriggerPhrases={handleUpdateTriggerPhrases}
-                      />
-                    </Resizable.Panel>
+                    <SkillDetailPane
+                      skill={visibleSkill()}
+                      loading={skillData.loading}
+                      error={skillData.error ?? null}
+                      workspaceId={props.workspaceId}
+                      onRetry={() => refetchSkill()}
+                      onUpdateTriggerPhrases={handleUpdateTriggerPhrases}
+                    />
                   </>
-                )}
-              </Resizable>
-            </Show>
-          </div>
+                }
+              >
+                <Resizable class="h-full" orientation="horizontal">
+                  {() => (
+                    <>
+                      <Resizable.Panel
+                        initialSize={0.382}
+                        minSize={0.25}
+                        maxSize={0.5}
+                        class="h-full bg-surface-raised rounded-lg overflow-hidden flex flex-col"
+                      >
+                        {listPaneContent()}
+                      </Resizable.Panel>
+
+                      <Resizable.Handle
+                        aria-label="Resize skill list panel"
+                        class="w-4 cursor-col-resize flex items-center justify-center group"
+                      >
+                        <div class="w-1 h-full bg-accent opacity-0 group-hover:opacity-100 transition-opacity" />
+                      </Resizable.Handle>
+
+                      <Resizable.Panel initialSize={0.618} minSize={0.5} class="h-full rounded-lg overflow-hidden">
+                        <SkillDetailPane
+                          skill={visibleSkill()}
+                          loading={skillData.loading}
+                          error={skillData.error ?? null}
+                          workspaceId={props.workspaceId}
+                          onRetry={() => refetchSkill()}
+                          onUpdateTriggerPhrases={handleUpdateTriggerPhrases}
+                        />
+                      </Resizable.Panel>
+                    </>
+                  )}
+                </Resizable>
+              </Show>
+            </div>
+          </ZIndexProvider>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog>

--- a/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillLibraryDialog.tsx
@@ -166,6 +166,16 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
     }
   };
 
+  const handleSearchQueryChange = (value: string) => {
+    setAutoScrollSkillId(null);
+    setSearchQuery(value);
+  };
+
+  const handleScopeFilterChange = (value: SkillListScopeFilter) => {
+    setAutoScrollSkillId(null);
+    setScopeFilter(value);
+  };
+
   const handleUpdateTriggerPhrases = async (phrases: string[]) => {
     const skill = skillData();
     if (!skill) return;
@@ -233,8 +243,8 @@ const SkillLibraryDialog: Component<SkillLibraryDialogProps> = (props) => {
       scopeFilter={scopeFilter()}
       selectedSkillId={selectedSkillId()}
       autoScrollSkillId={autoScrollSkillId()}
-      onSearchQueryChange={setSearchQuery}
-      onScopeFilterChange={setScopeFilter}
+      onSearchQueryChange={handleSearchQueryChange}
+      onScopeFilterChange={handleScopeFilterChange}
       onSelectSkill={selectSkill}
       onAutoScrollHandled={(skillId) => {
         if (autoScrollSkillId() === skillId) {

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
@@ -142,4 +142,50 @@ describe("SkillListPane", () => {
       expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
     });
   });
+
+  it("ignores a queued auto-scroll after the request is cleared", () => {
+    const scrollIntoView = vi.fn();
+    const queuedMicrotasks: Array<() => void> = [];
+
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+    vi.spyOn(globalThis, "queueMicrotask").mockImplementation((callback: VoidFunction) => {
+      queuedMicrotasks.push(callback);
+    });
+
+    const Wrapper = () => {
+      const [autoScrollSkillId, setAutoScrollSkillId] = createSignal<string | null>(skills[0]?.id ?? null);
+
+      return (
+        <>
+          <button type="button" onClick={() => setAutoScrollSkillId(null)}>
+            Cancel auto-scroll
+          </button>
+          <SkillListPane
+            skills={skills}
+            filteredSkills={skills}
+            searchQuery=""
+            scopeFilter="all"
+            selectedSkillId={skills[0]?.id ?? null}
+            autoScrollSkillId={autoScrollSkillId()}
+            onSearchQueryChange={() => {}}
+            onScopeFilterChange={() => {}}
+            onSelectSkill={() => {}}
+            onAutoScrollHandled={setAutoScrollSkillId}
+          />
+        </>
+      );
+    };
+
+    render(() => <Wrapper />);
+
+    expect(queuedMicrotasks).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel auto-scroll" }));
+
+    for (const runMicrotask of queuedMicrotasks) {
+      runMicrotask();
+    }
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
 });

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.test.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Tests the flat list pane used by the skills library dialog.
-// ABOUTME: Verifies search input, install location filter, and visible skill selection callbacks.
+// ABOUTME: Verifies search input, install location filter, and programmatic auto-scroll behavior.
 
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createMemo, createSignal } from "solid-js";
@@ -98,11 +98,15 @@ describe("SkillListPane", () => {
 
     const Wrapper = () => {
       const [selectedSkillId, setSelectedSkillId] = createSignal<string | null>(skills[0]?.id ?? null);
+      const [autoScrollSkillId, setAutoScrollSkillId] = createSignal<string | null>(skills[0]?.id ?? null);
 
       return (
         <>
           <button type="button" onClick={() => setSelectedSkillId("release-notes-from-branch")}>
             Select release notes
+          </button>
+          <button type="button" onClick={() => setAutoScrollSkillId("release-notes-from-branch")}>
+            Auto-scroll release notes
           </button>
           <SkillListPane
             skills={skills}
@@ -110,9 +114,11 @@ describe("SkillListPane", () => {
             searchQuery=""
             scopeFilter="all"
             selectedSkillId={selectedSkillId()}
+            autoScrollSkillId={autoScrollSkillId()}
             onSearchQueryChange={() => {}}
             onScopeFilterChange={() => {}}
             onSelectSkill={setSelectedSkillId}
+            onAutoScrollHandled={setAutoScrollSkillId}
           />
         </>
       );
@@ -126,6 +132,11 @@ describe("SkillListPane", () => {
 
     scrollIntoView.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Select release notes" }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Auto-scroll release notes" }));
 
     await waitFor(() => {
       expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
@@ -16,14 +16,16 @@ export interface SkillListPaneProps {
   searchQuery: string;
   scopeFilter: SkillListScopeFilter;
   selectedSkillId: string | null;
+  autoScrollSkillId?: string | null;
   onSearchQueryChange: (value: string) => void;
   onScopeFilterChange: (value: SkillListScopeFilter) => void;
   onSelectSkill: (skillId: string) => void;
+  onAutoScrollHandled?: (skillId: string) => void;
 }
 
 const SkillListPane: Component<SkillListPaneProps> = (props) => {
   const baseZIndex = useZIndex();
-  let selectedSkillButton: HTMLButtonElement | undefined;
+  let skillListRef: HTMLDivElement | undefined;
 
   const resultCountLabel = () => {
     const count = props.filteredSkills.length;
@@ -45,13 +47,22 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
   ];
 
   createEffect(
-    on([() => props.selectedSkillId, () => props.filteredSkills], ([selectedSkillId]) => {
-      if (!selectedSkillId) {
+    on([() => props.autoScrollSkillId, () => props.filteredSkills], ([autoScrollSkillId]) => {
+      if (!autoScrollSkillId) {
         return;
       }
 
       queueMicrotask(() => {
-        selectedSkillButton?.scrollIntoView({ block: "start" });
+        const selectedSkillButton = Array.from(
+          skillListRef?.querySelectorAll<HTMLButtonElement>("button[data-skill-id]") ?? [],
+        ).find((button) => button.dataset["skillId"] === autoScrollSkillId);
+
+        if (!selectedSkillButton) {
+          return;
+        }
+
+        selectedSkillButton.scrollIntoView({ block: "start" });
+        props.onAutoScrollHandled?.(autoScrollSkillId);
       });
     }),
   );
@@ -129,7 +140,7 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
         </div>
       </div>
 
-      <div class="flex-1 overflow-y-auto px-3">
+      <div ref={skillListRef} class="flex-1 overflow-y-auto px-3">
         <Show
           when={props.filteredSkills.length > 0}
           fallback={
@@ -142,11 +153,7 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
             {(skill) => (
               <button
                 type="button"
-                ref={(el) => {
-                  if (props.selectedSkillId === skill.id) {
-                    selectedSkillButton = el;
-                  }
-                }}
+                data-skill-id={skill.id}
                 onClick={() => props.onSelectSkill(skill.id)}
                 class="w-full text-left px-3 py-4 transition-colors border-b border-border-muted/40 last:border-b-0"
                 classList={{

--- a/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
+++ b/projects/birdhouse/frontend/src/skills/components/SkillListPane.tsx
@@ -26,6 +26,7 @@ export interface SkillListPaneProps {
 const SkillListPane: Component<SkillListPaneProps> = (props) => {
   const baseZIndex = useZIndex();
   let skillListRef: HTMLDivElement | undefined;
+  let autoScrollRequestId = 0;
 
   const resultCountLabel = () => {
     const count = props.filteredSkills.length;
@@ -48,11 +49,17 @@ const SkillListPane: Component<SkillListPaneProps> = (props) => {
 
   createEffect(
     on([() => props.autoScrollSkillId, () => props.filteredSkills], ([autoScrollSkillId]) => {
+      const requestId = ++autoScrollRequestId;
+
       if (!autoScrollSkillId) {
         return;
       }
 
       queueMicrotask(() => {
+        if (requestId !== autoScrollRequestId || props.autoScrollSkillId !== autoScrollSkillId) {
+          return;
+        }
+
         const selectedSkillButton = Array.from(
           skillListRef?.querySelectorAll<HTMLButtonElement>("button[data-skill-id]") ?? [],
         ).find((button) => button.dataset["skillId"] === autoScrollSkillId);

--- a/projects/birdhouse/server/src/lib/file-viewer.ts
+++ b/projects/birdhouse/server/src/lib/file-viewer.ts
@@ -1,0 +1,104 @@
+// ABOUTME: Reads viewable text files and detects a highlighting language for the file viewer.
+// ABOUTME: Rejects invalid paths, directories, oversized files, and obvious binary content.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, extname } from "node:path";
+
+const MAX_FILE_VIEW_BYTES = 1024 * 1024;
+
+const LANGUAGE_BY_FILENAME: Record<string, string> = {
+  dockerfile: "dockerfile",
+  makefile: "makefile",
+};
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  ts: "typescript",
+  tsx: "tsx",
+  js: "javascript",
+  jsx: "jsx",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+  java: "java",
+  c: "c",
+  cpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  yaml: "yaml",
+  yml: "yaml",
+  json: "json",
+  md: "markdown",
+  markdown: "markdown",
+  html: "html",
+  css: "css",
+  scss: "scss",
+  sql: "sql",
+  xml: "xml",
+  txt: "text",
+  toml: "toml",
+};
+
+export interface ViewableFile {
+  path: string;
+  name: string;
+  content: string;
+  language: string;
+  is_markdown: boolean;
+}
+
+export type ReadViewableFileErrorCode = "invalid_path" | "not_found" | "not_file" | "too_large" | "binary";
+
+export class ReadViewableFileError extends Error {
+  code: ReadViewableFileErrorCode;
+
+  constructor(code: ReadViewableFileErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export function detectFileViewerLanguage(filePath: string): string {
+  const filename = basename(filePath).toLowerCase();
+  const extension = extname(filePath).slice(1).toLowerCase();
+
+  return LANGUAGE_BY_FILENAME[filename] ?? LANGUAGE_BY_EXTENSION[extension] ?? "text";
+}
+
+export function readViewableFile(filePath: string): ViewableFile {
+  if (!filePath || !filePath.startsWith("/")) {
+    throw new ReadViewableFileError("invalid_path", "path must be an absolute file path");
+  }
+
+  if (!existsSync(filePath)) {
+    throw new ReadViewableFileError("not_found", "File not found");
+  }
+
+  const fileStats = statSync(filePath);
+  if (!fileStats.isFile()) {
+    throw new ReadViewableFileError("not_file", "Only regular files can be viewed");
+  }
+
+  if (fileStats.size > MAX_FILE_VIEW_BYTES) {
+    throw new ReadViewableFileError("too_large", `File exceeds ${MAX_FILE_VIEW_BYTES} byte limit`);
+  }
+
+  const buffer = readFileSync(filePath);
+  if (buffer.includes(0)) {
+    throw new ReadViewableFileError("binary", "Only text files can be viewed");
+  }
+
+  const content = buffer.toString("utf-8");
+  const language = detectFileViewerLanguage(filePath);
+
+  return {
+    path: filePath,
+    name: basename(filePath),
+    content,
+    language,
+    is_markdown: language === "markdown",
+  };
+}

--- a/projects/birdhouse/server/src/lib/file-viewer.ts
+++ b/projects/birdhouse/server/src/lib/file-viewer.ts
@@ -1,8 +1,9 @@
-// ABOUTME: Reads viewable text files and detects a highlighting language for the file viewer.
-// ABOUTME: Rejects invalid paths, directories, oversized files, and obvious binary content.
+// ABOUTME: Reads viewable text files, detects highlighting languages, and reveals files in the OS file manager.
+// ABOUTME: Rejects invalid paths, directories, oversized files, and obvious binary content for the file viewer.
 
+import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { basename, extname } from "node:path";
+import { basename, dirname, extname } from "node:path";
 
 const MAX_FILE_VIEW_BYTES = 1024 * 1024;
 
@@ -61,6 +62,12 @@ export class ReadViewableFileError extends Error {
   }
 }
 
+type SpawnLike = (
+  command: string,
+  args: string[],
+  options: { detached: true; stdio: "ignore" },
+) => Pick<ChildProcess, "unref">;
+
 export function detectFileViewerLanguage(filePath: string): string {
   const filename = basename(filePath).toLowerCase();
   const extension = extname(filePath).slice(1).toLowerCase();
@@ -101,4 +108,30 @@ export function readViewableFile(filePath: string): ViewableFile {
     language,
     is_markdown: language === "markdown",
   };
+}
+
+export function revealFileInFileManager(
+  filePath: string,
+  platform: NodeJS.Platform = process.platform,
+  spawnProcess: SpawnLike = spawn,
+): void {
+  let command: string;
+  let args: string[];
+
+  if (platform === "darwin") {
+    command = "open";
+    args = ["-R", filePath];
+  } else if (platform === "win32") {
+    command = "explorer";
+    args = ["/select,", filePath];
+  } else {
+    command = "xdg-open";
+    args = [dirname(filePath)];
+  }
+
+  const child = spawnProcess(command, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
 }

--- a/projects/birdhouse/server/src/routes/files.test.ts
+++ b/projects/birdhouse/server/src/routes/files.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Tests workspace-scoped file routes for file search and read-only file viewing.
+// ABOUTME: Verifies the file viewer endpoint returns text content safely and rejects invalid paths.
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createMockWorkspace, createTestApp } from "../test-utils";
+import { createFileRoutes } from "./files";
+
+describe("workspace file routes", () => {
+  test("returns markdown file content and viewer metadata", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "birdhouse-file-viewer-"));
+
+    try {
+      const filePath = join(tempDir, "references", "notes.md");
+      mkdirSync(join(filePath, ".."), { recursive: true });
+      writeFileSync(filePath, "# Notes\n\nHello from markdown.\n", "utf-8");
+
+      const app = await createTestApp({ workspace: createMockWorkspace({ directory: tempDir }) });
+      app.route("/", createFileRoutes());
+
+      const response = await app.request(`/view?path=${encodeURIComponent(filePath)}`);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        path: filePath,
+        name: "notes.md",
+        content: "# Notes\n\nHello from markdown.\n",
+        language: "markdown",
+        is_markdown: true,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects relative paths", async () => {
+    const app = await createTestApp({ workspace: createMockWorkspace() });
+    app.route("/", createFileRoutes());
+
+    const response = await app.request("/view?path=notes.md");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "path must be an absolute file path" });
+  });
+
+  test("rejects binary files", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "birdhouse-file-viewer-"));
+
+    try {
+      const filePath = join(tempDir, "binary.bin");
+      writeFileSync(filePath, Buffer.from([0x00, 0x01, 0x02, 0x03]));
+
+      const app = await createTestApp({ workspace: createMockWorkspace({ directory: tempDir }) });
+      app.route("/", createFileRoutes());
+
+      const response = await app.request(`/view?path=${encodeURIComponent(filePath)}`);
+
+      expect(response.status).toBe(415);
+      expect(await response.json()).toEqual({ error: "Only text files can be viewed" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/projects/birdhouse/server/src/routes/files.test.ts
+++ b/projects/birdhouse/server/src/routes/files.test.ts
@@ -79,4 +79,36 @@ describe("workspace file routes", () => {
     expect(await response.json()).toEqual({ success: true, path: "/Users/test/references/notes.md" });
     expect(revealFile).toHaveBeenCalledWith("/Users/test/references/notes.md");
   });
+
+  test("rejects malformed JSON bodies for reveal", async () => {
+    const revealFile = mock(() => {});
+    const app = await createTestApp({ workspace: createMockWorkspace() });
+    app.route("/", createFileRoutes({ revealFileInFileManager: revealFile }));
+
+    const response = await app.request("/reveal", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON body" });
+    expect(revealFile).not.toHaveBeenCalled();
+  });
+
+  test("rejects null JSON bodies for reveal", async () => {
+    const revealFile = mock(() => {});
+    const app = await createTestApp({ workspace: createMockWorkspace() });
+    app.route("/", createFileRoutes({ revealFileInFileManager: revealFile }));
+
+    const response = await app.request("/reveal", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "null",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "path must be an absolute file path" });
+    expect(revealFile).not.toHaveBeenCalled();
+  });
 });

--- a/projects/birdhouse/server/src/routes/files.test.ts
+++ b/projects/birdhouse/server/src/routes/files.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests workspace-scoped file routes for file search and read-only file viewing.
 // ABOUTME: Verifies the file viewer endpoint returns text content safely and rejects invalid paths.
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -62,5 +62,21 @@ describe("workspace file routes", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  test("reveals an absolute file path in the file manager", async () => {
+    const revealFile = mock(() => {});
+    const app = await createTestApp({ workspace: createMockWorkspace() });
+    app.route("/", createFileRoutes({ revealFileInFileManager: revealFile }));
+
+    const response = await app.request("/reveal", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "/Users/test/references/notes.md" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, path: "/Users/test/references/notes.md" });
+    expect(revealFile).toHaveBeenCalledWith("/Users/test/references/notes.md");
   });
 });

--- a/projects/birdhouse/server/src/routes/files.ts
+++ b/projects/birdhouse/server/src/routes/files.ts
@@ -37,8 +37,16 @@ export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
   });
 
   app.post("/reveal", async (c) => {
-    const body = await c.req.json();
-    const filePath = typeof body.path === "string" ? body.path : "";
+    let body: unknown;
+
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const filePath =
+      body && typeof body === "object" && "path" in body && typeof body.path === "string" ? body.path : "";
 
     if (!filePath.startsWith("/")) {
       return c.json({ error: "path must be an absolute file path" }, 400);

--- a/projects/birdhouse/server/src/routes/files.ts
+++ b/projects/birdhouse/server/src/routes/files.ts
@@ -2,12 +2,17 @@
 // ABOUTME: Provides endpoints for OpenCode-backed file search and local text file inspection.
 
 import { Hono } from "hono";
-import { ReadViewableFileError, readViewableFile } from "../lib/file-viewer";
+import { ReadViewableFileError, readViewableFile, revealFileInFileManager } from "../lib/file-viewer";
 import { createLiveOpenCodeClient } from "../lib/opencode-client";
 import "../types/context";
 
-export function createFileRoutes() {
+interface CreateFileRoutesOptions {
+  revealFileInFileManager?: typeof revealFileInFileManager;
+}
+
+export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
   const app = new Hono();
+  const revealFile = options.revealFileInFileManager ?? revealFileInFileManager;
 
   app.get("/view", async (c) => {
     const filePath = c.req.query("path");
@@ -29,6 +34,18 @@ export function createFileRoutes() {
 
       throw error;
     }
+  });
+
+  app.post("/reveal", async (c) => {
+    const body = await c.req.json();
+    const filePath = typeof body.path === "string" ? body.path : "";
+
+    if (!filePath.startsWith("/")) {
+      return c.json({ error: "path must be an absolute file path" }, 400);
+    }
+
+    revealFile(filePath);
+    return c.json({ success: true, path: filePath });
   });
 
   // POST /api/files/find/files - Find files and directories by name/pattern

--- a/projects/birdhouse/server/src/routes/files.ts
+++ b/projects/birdhouse/server/src/routes/files.ts
@@ -1,12 +1,35 @@
-// ABOUTME: File searching routes that forward to OpenCode's Files SDK
-// ABOUTME: Provides endpoints for finding files in the workspace using the OpencodeClient
+// ABOUTME: File routes for workspace search and read-only file viewing.
+// ABOUTME: Provides endpoints for OpenCode-backed file search and local text file inspection.
 
 import { Hono } from "hono";
+import { ReadViewableFileError, readViewableFile } from "../lib/file-viewer";
 import { createLiveOpenCodeClient } from "../lib/opencode-client";
 import "../types/context";
 
 export function createFileRoutes() {
   const app = new Hono();
+
+  app.get("/view", async (c) => {
+    const filePath = c.req.query("path");
+
+    try {
+      return c.json(readViewableFile(filePath ?? ""));
+    } catch (error) {
+      if (error instanceof ReadViewableFileError) {
+        const statusByCode: Record<ReadViewableFileError["code"], 400 | 404 | 413 | 415> = {
+          invalid_path: 400,
+          not_found: 404,
+          not_file: 400,
+          too_large: 413,
+          binary: 415,
+        };
+
+        return c.json({ error: error.message }, statusByCode[error.code]);
+      }
+
+      throw error;
+    }
+  });
 
   // POST /api/files/find/files - Find files and directories by name/pattern
   app.post("/find/files", async (c) => {


### PR DESCRIPTION
## What's New

### ✨ Features
- Added a generic read-only file viewer that can open any absolute text file path with Birdhouse theming and syntax highlighting.
- Markdown files now open in rich mode by default with a `Rich | Raw` toggle, while non-markdown files open directly in raw/code view.
- Supporting files in the Skills Library are now clickable and open in the generic file viewer.
- Added a reveal-in-Finder action to the file viewer so the currently viewed file can be opened in the OS file manager.

### 🐛 Fixes
- Fixed Skills Library list scrolling so auto-scroll only happens for programmatic opens from skill references, not for normal user list clicks.
- Fixed the skill detail pane so switching to a different skill resets the right-side scroll position back to the top.
- Fixed modal layering so the file viewer presents above the Skills Library instead of appearing behind it.

---

## Technical Changes

### 🏗️ Infrastructure
- Extended the existing workspace `/files` route family with read-only file viewing and reveal endpoints.
- Added server-side file viewing guards for absolute paths, regular files, text-only reads, and size-limited content loading.

### 🧹 Code Quality
- Introduced a small `frontend/src/file-viewer/` feature folder for the reusable dialog, API client, path helper, and tests.
- Kept the file viewer decoupled from Skills-specific state so it can be reused by other parts of the app later.
- Refined Skills Library selection behavior with explicit programmatic scroll intent instead of broad reactive auto-scroll triggers.

## Testing
- `bun test src/routes/files.test.ts`
- `bun run typecheck` in `projects/birdhouse/server`
- `bun run lint` in `projects/birdhouse/server`
- `bun --bun vitest run src/file-viewer/components/FileViewerDialog.test.tsx src/skills/components/SkillDetailContent.test.tsx src/skills/components/SkillDetailModal.test.tsx src/skills/components/SkillLibraryDialog.test.tsx src/skills/components/SkillListPane.test.tsx`
- `bun run typecheck` in `projects/birdhouse/frontend`
- `bun run lint` in `projects/birdhouse/frontend`
- Manual isolated Birdhouse browser testing with screenshots and MP4 capture for:
  - generic file viewer happy path
  - modal layering retest
  - markdown rich/raw toggle
  - non-markdown raw/code view
