### PR TITLE
llm/generate: remove maxTokens cap for title generation

### DIFF
--- a/projects/birdhouse/server/src/lib/opencode-client.ts
+++ b/projects/birdhouse/server/src/lib/opencode-client.ts
@@ -288,7 +288,7 @@ export function createLiveOpenCodeClient(baseUrl: string, workspaceRoot: string)
           system: options.system,
           message: options.message,
           small: options.small ?? true,
-          maxTokens: options.maxTokens ?? 300,
+          ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
         }),
       });
       if (!response.ok) {

--- a/projects/birdhouse/server/src/lib/title-generator.test.ts
+++ b/projects/birdhouse/server/src/lib/title-generator.test.ts
@@ -56,7 +56,6 @@ describe("title-generator", () => {
       system: undefined,
       message: buildTitleMessage("Create a function to sort arrays"),
       small: true,
-      maxTokens: 300,
     });
   });
 

--- a/projects/birdhouse/server/src/lib/title-generator.ts
+++ b/projects/birdhouse/server/src/lib/title-generator.ts
@@ -59,7 +59,6 @@ export async function generateTitle(
       system: systemInstructions.length > 0 ? systemInstructions : undefined,
       message: buildTitleMessage(message),
       small: true,
-      maxTokens: 300,
     });
 
     if (!title || title.trim() === "") {


### PR DESCRIPTION
## Summary

Fixes title generation failing silently when big-pickle (a reasoning model) is the active small model.

## Root cause

`opencode-client.ts` was unconditionally sending `maxTokens: 300` on every `/llm/generate` call, even when the caller didn't request a cap. `title-generator.ts` relied on this default.

Reasoning models like big-pickle spend token budget on internal `<think>` blocks before emitting visible text. With only 300 tokens available, the model exhausted its budget during reasoning and returned nothing — triggering the "empty response" error in title generation.

## Changes

- **`opencode-client.ts`**: Only send `maxTokens` when the caller explicitly provides it. Removes the `?? 300` default that was silently capping all generate calls.
- **`title-generator.ts`**: Remove the explicit `maxTokens: 300` from the title generation call. Matches upstream opencode's title generation behavior, which never caps output tokens.

The think-block strip (`/<think>[\s\S]*?<\/think>/g`) that handles the reasoning model output lives on the opencode side in the `/llm/generate` handler.

## Testing

Manually verified title generation works end-to-end against the v1.16.2 rebase of opencode running in sandbox1, with big-pickle as the active model.