### PR TITLE
Sandbox worktree setup: start-sandbox fix, setup script, skill docs

### DIFF
--- a/.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md
+++ b/.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md
@@ -78,6 +78,87 @@ Each run keeps:
 
 Treat the run directory as the review package. Do not auto-delete it after a successful test.
 
+## Running from a Worktree
+
+Use a Birdhouse worktree instead of the main clone when:
+
+- testing a feature branch in isolation before merging
+- running a rebase against a new OpenCode version (e.g. verifying a `v1.16.2` build)
+
+### Two-worktree pattern
+
+You need two worktrees: one for Birdhouse, one for OpenCode.
+
+**Birdhouse worktree** — a normal git worktree on your feature branch:
+
+```bash
+git worktree add worktrees/my-feature -b my-feature origin/main
+```
+
+**OpenCode worktree** — typically a checked-out tag or rebase target, e.g.:
+
+```
+/tmp/opencode-v1.16.2
+```
+
+### Setup steps
+
+1. Create the Birdhouse worktree (if not already done):
+
+   ```bash
+   git worktree add worktrees/my-feature -b my-feature origin/main
+   ```
+
+2. Prepare it (installs server deps and builds the frontend dist):
+
+   ```bash
+   bash sandboxes/setup-worktree.sh --worktree worktrees/my-feature
+   ```
+
+3. Start the sandbox pointing at both worktrees:
+
+   ```bash
+   bash sandboxes/start-sandbox.sh \
+     --sandbox sandbox1 \
+     --opencode-path /tmp/opencode-v1.16.2 \
+     --worktree /abs/path/to/worktrees/my-feature
+   ```
+
+   Use an absolute path for `--worktree`.
+
+### OpenCode worktree quick setup
+
+OpenCode needs its own preparation before `start-sandbox.sh` will accept it:
+
+1. `bun install` in the opencode repo root
+2. Copy the Birdhouse plugin source into `packages/opencode/src/birdhouse/`
+
+For the full rebase workflow and plugin copy steps, see the `opencode-rebase` skill.
+
+### Verifying both sides are running the right code
+
+After the sandbox starts, confirm each side is serving from the expected directory:
+
+**OpenCode** — confirm working directory:
+
+```bash
+lsof -p $(lsof -ti tcp:50210) | grep cwd
+```
+
+**OpenCode fork identity** — must contain `birdhouseWorkspaceId`:
+
+```bash
+curl -s http://127.0.0.1:50210/global/health
+```
+
+**Birdhouse server** — confirm working directory:
+
+```bash
+lsof -p $(lsof -ti tcp:50200) | grep cwd
+```
+
+Adjust ports if you used sandbox2 (`50220`/`50230`) or another block.
+
 ## Delegation Pattern
 
 Parent or implementation agents should delegate browser testing to child agents. Those browser agents should be long-lived enough to accept retest instructions by reply.

--- a/.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md
+++ b/.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md
@@ -165,6 +165,8 @@ lsof -p $(lsof -ti tcp:50200) | grep cwd
 
 Adjust ports if you used sandbox2 (`50220`/`50230`) or another block.
 
+**Common failure:** `start-sandbox.sh` checks if a healthy process is already on the port and returns early without restarting. If the `cwd` check shows the main clone instead of your worktree, the old process is still running. Stop it with `bash sandboxes/stop-sandbox.sh --sandbox sandbox1` and start again with `--worktree`.
+
 ## Delegation Pattern
 
 Parent or implementation agents should delegate browser testing to child agents. Those browser agents should be long-lived enough to accept retest instructions by reply.

--- a/.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md
+++ b/.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md
@@ -126,12 +126,18 @@ git worktree add worktrees/my-feature -b my-feature origin/main
 
    Use an absolute path for `--worktree`.
 
+**Note on `.env`:** Worktrees do not have a `.env` file, and `start-sandbox.sh` does not need one. All required env vars (`BIRDHOUSE_BASE_PORT`, `OPENCODE_PATH`, `BIRDHOUSE_DATA_DB_PATH`, `FRONTEND_STATIC`) are passed explicitly by the script. Do not copy `.env` from the main clone — it contains machine-specific paths and a hardcoded `OPENCODE_PATH` that will conflict with sandbox configuration.
+
 ### OpenCode worktree quick setup
 
 OpenCode needs its own preparation before `start-sandbox.sh` will accept it:
 
 1. `bun install` in the opencode repo root
-2. Copy the Birdhouse plugin source into `packages/opencode/src/birdhouse/`
+2. Copy the Birdhouse plugin source:
+   ```bash
+   cp projects/birdhouse-oc-plugin/src/plugin.ts \
+     <opencode-path>/packages/opencode/src/plugin/birdhouse.ts
+   ```
 
 For the full rebase workflow and plugin copy steps, see the `opencode-rebase` skill.
 

--- a/.agents/skills/internal/birdhouse-development/opencode-rebase/SKILL.md
+++ b/.agents/skills/internal/birdhouse-development/opencode-rebase/SKILL.md
@@ -69,9 +69,9 @@ You may use `git cherry-pick` when a commit applies cleanly and you have inspect
 
 5. If the fork includes built-in Birdhouse plugin support, ensure the ignored plugin source file exists in the worktree before typecheck/build validation:
    ```bash
-   cp <birdhouse-plugin-source> packages/opencode/src/plugin/birdhouse.ts
+   cp projects/birdhouse-oc-plugin/src/plugin.ts packages/opencode/src/plugin/birdhouse.ts
    ```
-   In Birdhouse, the source of truth is the plugin implementation used by the monorepo build/dev sync flow. Check the Birdhouse build scripts or dev plugin sync utility if the source path is unclear.
+   Run this from the birdhouse-workspace root. The source lives in `projects/birdhouse-oc-plugin/src/plugin.ts` and the destination is always `packages/opencode/src/plugin/birdhouse.ts` relative to the opencode worktree root.
 
 6. Review commits before applying them.
    - Open the old diff with `git show <hash>`.
@@ -219,12 +219,34 @@ After the full port and CI pass, run the agentic test suite against the new work
 
 Load the `birdhouse-agentic-tests` skill (at `file:///Users/crayment/dev/birdhouse-workspace/.agents/skills/internal/birdhouse-development/birdhouse-agentic-tests/SKILL.md`). Run all tests and confirm every test passes before considering the rebase done.
 
-**Important:** start sandbox1 with the rebase worktree path, not the default:
+**Important:** start sandbox1 pointing at both the rebase worktree (opencode) and a prepared Birdhouse worktree. Without `--worktree`, the sandbox runs Birdhouse from the main clone, which may be on a different branch and will not reflect any Birdhouse-side changes made during the rebase.
+
+First prepare the Birdhouse worktree if you haven't already:
 ```bash
-bash sandboxes/start-sandbox.sh --sandbox sandbox1 \
-  --opencode-path /tmp/opencode-v<version>
+bash sandboxes/setup-worktree.sh --worktree worktrees/<your-birdhouse-worktree>
 ```
-Replace `<version>` with the new upstream tag (e.g. `1.4.12`). This runs the tests against the in-progress rebase, not the already-merged `birdhouse` branch. The default opencode path (`.worktrees/opencode-birdhouse`) points at the merged branch and would not test your new work.
+
+Then start the sandbox:
+```bash
+bash sandboxes/start-sandbox.sh \
+  --sandbox sandbox1 \
+  --opencode-path /tmp/opencode-v<version> \
+  --worktree "$(pwd)/worktrees/<your-birdhouse-worktree>"
+```
+
+After starting, verify both sides are serving from the expected directories:
+```bash
+# OpenCode — must show /tmp/opencode-v<version>/packages/opencode
+lsof -p $(lsof -ti tcp:50210) | grep cwd
+
+# Birdhouse — must show your worktree path, not the main clone
+lsof -p $(lsof -ti tcp:50200) | grep cwd
+
+# Fork identity — must contain birdhouseWorkspaceId
+curl -s http://127.0.0.1:50210/global/health
+```
+
+If the cwd check shows the main clone instead of your worktree, the sandbox started against the old Birdhouse — stop, check the `--worktree` argument, and restart.
 
 ## Key Reminders
 

--- a/.agents/skills/internal/birdhouse-development/opencode-rebase/SKILL.md
+++ b/.agents/skills/internal/birdhouse-development/opencode-rebase/SKILL.md
@@ -69,9 +69,9 @@ You may use `git cherry-pick` when a commit applies cleanly and you have inspect
 
 5. If the fork includes built-in Birdhouse plugin support, ensure the ignored plugin source file exists in the worktree before typecheck/build validation:
    ```bash
-   cp projects/birdhouse-oc-plugin/src/plugin.ts packages/opencode/src/plugin/birdhouse.ts
+   cp projects/birdhouse-oc-plugin/src/plugin.ts <opencode-worktree>/packages/opencode/src/plugin/birdhouse.ts
    ```
-   Run this from the birdhouse-workspace root. The source lives in `projects/birdhouse-oc-plugin/src/plugin.ts` and the destination is always `packages/opencode/src/plugin/birdhouse.ts` relative to the opencode worktree root.
+   Run this from the birdhouse-workspace root. The source lives in `projects/birdhouse-oc-plugin/src/plugin.ts`. Replace `<opencode-worktree>` with the absolute path to the opencode worktree (e.g. `/tmp/opencode-v1.16.2`).
 
 6. Review commits before applying them.
    - Open the old diff with `git show <hash>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,8 @@ When working in this workspace:
 - **Read project READMEs** to understand dependencies and build processes
 - **Follow commit style guide** at [`docs/git-commit-style.md`](docs/git-commit-style.md) - required reading for all git commits
 - **Commit Often** We like small commits. Easy to squash later!
-- **Logging & reading logs** — load the [logging skill](.agents/skills/internal/birdhouse-development/logging/SKILL.md)
+ - **Logging & reading logs** — load the [logging skill](.agents/skills/internal/birdhouse-development/logging/SKILL.md)
+ - **Running Birdhouse from a worktree** (feature branches, rebase testing) — load the [isolated-birdhouse-web-testing skill](.agents/skills/internal/birdhouse-development/isolated-birdhouse-web-testing/SKILL.md) and read the "Running from a Worktree" section
 
 ## Working with Agents
 

--- a/sandboxes/setup-worktree.sh
+++ b/sandboxes/setup-worktree.sh
@@ -9,6 +9,10 @@ WORKTREE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --worktree)
+      if [[ $# -lt 2 ]]; then
+        printf 'Error: --worktree requires an argument\n' >&2
+        exit 1
+      fi
       WORKTREE="$2"
       shift 2
       ;;

--- a/sandboxes/setup-worktree.sh
+++ b/sandboxes/setup-worktree.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ABOUTME: Prepares a Birdhouse worktree for sandbox use by installing dependencies and building the frontend.
+# ABOUTME: Run this once after creating a worktree before using start-sandbox.sh --worktree.
+
+set -euo pipefail
+
+WORKTREE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --worktree)
+      WORKTREE="$2"
+      shift 2
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$WORKTREE" ]]; then
+  printf 'Usage: %s --worktree <path>\n' "$0" >&2
+  exit 1
+fi
+
+if [[ ! -d "$WORKTREE" ]]; then
+  printf 'Worktree path does not exist: %s\n' "$WORKTREE" >&2
+  exit 1
+fi
+
+SERVER_DIR="$WORKTREE/projects/birdhouse/server"
+FRONTEND_DIR="$WORKTREE/projects/birdhouse/frontend"
+
+if [[ ! -d "$SERVER_DIR" ]]; then
+  printf 'Expected server directory at %s\n' "$SERVER_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -d "$FRONTEND_DIR" ]]; then
+  printf 'Expected frontend directory at %s\n' "$FRONTEND_DIR" >&2
+  exit 1
+fi
+
+printf '==> Installing server dependencies in %s\n' "$SERVER_DIR"
+(cd "$SERVER_DIR" && bun install)
+
+printf '==> Building frontend in %s\n' "$FRONTEND_DIR"
+(cd "$FRONTEND_DIR" && bun run build)
+
+printf '\n'
+printf 'Worktree ready: %s\n' "$WORKTREE"
+printf '\n'
+printf 'Next steps:\n'
+printf '  bash sandboxes/start-sandbox.sh \\\n'
+printf '    --sandbox sandbox1 \\\n'
+printf '    --opencode-path <opencode-repo-path> \\\n'
+printf '    --worktree %s\n' "$WORKTREE"

--- a/sandboxes/setup-worktree.sh
+++ b/sandboxes/setup-worktree.sh
@@ -51,6 +51,11 @@ printf '==> Building frontend in %s\n' "$FRONTEND_DIR"
 printf '\n'
 printf 'Worktree ready: %s\n' "$WORKTREE"
 printf '\n'
+printf 'Note: worktrees do not have a .env file. start-sandbox.sh passes all\n'
+printf 'required env vars (BIRDHOUSE_BASE_PORT, OPENCODE_PATH, etc.) explicitly.\n'
+printf 'Do not copy .env from the main clone — it contains machine-specific paths\n'
+printf 'that will conflict with sandbox configuration.\n'
+printf '\n'
 printf 'Next steps:\n'
 printf '  bash sandboxes/start-sandbox.sh \\\n'
 printf '    --sandbox sandbox1 \\\n'

--- a/sandboxes/start-sandbox.sh
+++ b/sandboxes/start-sandbox.sh
@@ -11,14 +11,17 @@ WORKTREE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --sandbox)
+      if [[ $# -lt 2 ]]; then printf 'Error: --sandbox requires an argument\n' >&2; exit 1; fi
       SANDBOX="$2"
       shift 2
       ;;
     --opencode-path)
+      if [[ $# -lt 2 ]]; then printf 'Error: --opencode-path requires an argument\n' >&2; exit 1; fi
       OPENCODE_PATH="$2"
       shift 2
       ;;
     --worktree)
+      if [[ $# -lt 2 ]]; then printf 'Error: --worktree requires an argument\n' >&2; exit 1; fi
       WORKTREE="$2"
       shift 2
       ;;

--- a/sandboxes/start-sandbox.sh
+++ b/sandboxes/start-sandbox.sh
@@ -89,16 +89,12 @@ fi
 mkdir -p "$SANDBOX_DIR/workspace" "$SANDBOX_DIR/screenshots"
 
 cd "$SERVER_DIR"
-# Use --env-file so bun loads the same project .env that the dev server uses
-# (needed for Hono static/route initialization to work correctly).
-# Our explicit env vars are set in the process environment BEFORE bun runs,
-# so they take precedence over any conflicting values in .env.
 nohup env \
   BIRDHOUSE_BASE_PORT="$BASE_PORT" \
   BIRDHOUSE_DATA_DB_PATH="$DATA_DB_PATH" \
   FRONTEND_STATIC="$FRONTEND_STATIC" \
   OPENCODE_PATH="$OPENCODE_PATH" \
-  bun --env-file=../.env src/index.ts >"$SERVER_LOG" 2>&1 &
+  bun src/index.ts >"$SERVER_LOG" 2>&1 </dev/null &
 server_pid=$!
 printf '%s\n' "$server_pid" >"$SERVER_PID_FILE"
 

--- a/sandboxes/start-sandbox.sh
+++ b/sandboxes/start-sandbox.sh
@@ -54,7 +54,9 @@ if [[ ! -d "$SERVER_DIR" ]]; then
 fi
 
 if [[ ! -d "$FRONTEND_STATIC" ]]; then
-  printf 'Expected built frontend at %s. Run bun run build in projects/birdhouse/frontend first.\n' "$FRONTEND_STATIC" >&2
+  printf 'Expected built frontend at %s.\n' "$FRONTEND_STATIC" >&2
+  printf 'If running from a worktree, run: bash sandboxes/setup-worktree.sh --worktree %s\n' "$WORKTREE" >&2
+  printf 'If running from the main clone, run: bun run build in projects/birdhouse/frontend\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What

Improves the experience of running an isolated Birdhouse sandbox from a feature branch worktree, alongside an isolated OpenCode worktree. This came out of the v1.16.2 rebase session where we hit several friction points doing this manually.

## Changes

**`start-sandbox.sh`**
- Remove `--env-file=../.env` from the bun launch command. The `.env` file is gitignored, doesn't exist in worktrees, and isn't needed — all required vars are passed as explicit env vars already.
- Add `</dev/null` to the background launch so the process fully detaches from the parent shell on macOS. Without this, the process is killed when the calling shell session ends (which happens with bash tool timeouts).

**`sandboxes/setup-worktree.sh`** (new)
- Prepares a Birdhouse worktree for sandbox use in one command: runs `bun install` in `projects/birdhouse/server` and `bun run build` in `projects/birdhouse/frontend`.
- Prints a success summary with the exact `start-sandbox.sh` command to run next.
- Error message in `start-sandbox.sh` now points to this script when the frontend dist is missing.

**`isolated-birdhouse-web-testing` skill**
- New "Running from a Worktree" section documenting the two-worktree pattern (Birdhouse + OpenCode), setup steps, and cwd/health verification commands.
- Common failure note: `start-sandbox.sh` returns early if a healthy process is already on the port — if the cwd check shows the main clone, stop and restart with `--worktree`.

**`opencode-rebase` skill**
- Replace `<birdhouse-plugin-source>` placeholder with the concrete workspace-relative path.
- Add `--worktree` flag to the agentic test startup command — without it the sandbox silently runs Birdhouse from the main clone.
- Expand post-rebase agentic test section with `setup-worktree.sh` step and explicit cwd verification block.

**`AGENTS.md`**
- One-line reference to the `isolated-birdhouse-web-testing` skill for worktree setup.

## Testing

All changes validated during the v1.16.2 rebase session. The `start-sandbox.sh` fix and `setup-worktree.sh` script were exercised directly.